### PR TITLE
Conditionally compile test code using UNIT_TESTING_ENABLED

### DIFF
--- a/CMSISv2p00_LPC17xx/Drivers/tests/inc/lpc17xx_exti_tests.h
+++ b/CMSISv2p00_LPC17xx/Drivers/tests/inc/lpc17xx_exti_tests.h
@@ -1,6 +1,8 @@
 #ifndef LPC17XX_EXTI_TESTS_H
 #define LPC17XX_EXTI_TESTS_H
 
+#ifdef UNIT_TESTING_ENABLED
+
 #define EXTI_MASK   0xF
 
 #include "lpc17xx_exti.h"
@@ -9,4 +11,5 @@
 
 void EXTI_RunTests(void);
 
+#endif // UNIT_TESTING_ENABLED
 #endif //LPC17XX_EXTI_TESTS_H

--- a/CMSISv2p00_LPC17xx/Drivers/tests/inc/lpc17xx_gpio_tests.h
+++ b/CMSISv2p00_LPC17xx/Drivers/tests/inc/lpc17xx_gpio_tests.h
@@ -1,10 +1,13 @@
 #ifndef LPC17XX_GPIO_TESTS_H
 #define LPC17XX_GPIO_TESTS_H
 
+#ifdef UNIT_TESTING_ENABLED
+
 #include "lpc17xx_gpio.h"
 #include "test_asserts.h"
 #include "test_utils.h"
 
 void GPIO_RunTests(void);
 
+#endif //UNIT_TESTING_ENABLED
 #endif //LPC17XX_GPIO_TESTS_H

--- a/CMSISv2p00_LPC17xx/Drivers/tests/inc/lpc17xx_pinsel_tests.h
+++ b/CMSISv2p00_LPC17xx/Drivers/tests/inc/lpc17xx_pinsel_tests.h
@@ -1,10 +1,13 @@
 #ifndef LPC17XX_PINSEL_TESTS_H
 #define LPC17XX_PINSEL_TESTS_H
 
+#ifdef UNIT_TESTING_ENABLED
+
 #include "lpc17xx_pinsel.h"
 #include "test_asserts.h"
 #include "test_utils.h"
 
 void PINSEL_RunTests(void);
 
+#endif // UNIT_TESTING_ENABLED
 #endif //LPC17XX_PINSEL_TESTS_H

--- a/CMSISv2p00_LPC17xx/Drivers/tests/inc/lpc17xx_systick_tests.h
+++ b/CMSISv2p00_LPC17xx/Drivers/tests/inc/lpc17xx_systick_tests.h
@@ -1,10 +1,13 @@
 #ifndef LPC17XX_SYSTICK_TESTS_H
 #define LPC17XX_SYSTICK_TESTS_H
 
+#ifdef UNIT_TESTING_ENABLED
+
 #include "lpc17xx_systick.h"
 #include "test_asserts.h"
 #include "test_utils.h"
 
 void SYSTICK_RunTests(void);
 
+#endif //UNIT_TESTING_ENABLED
 #endif //LPC17XX_SYSTICK_TESTS_H

--- a/CMSISv2p00_LPC17xx/Drivers/tests/inc/lpc17xx_timer_tests.h
+++ b/CMSISv2p00_LPC17xx/Drivers/tests/inc/lpc17xx_timer_tests.h
@@ -1,10 +1,13 @@
 #ifndef LPC17XX_TIMER_TESTS_H
 #define LPC17XX_TIMER_TESTS_H
 
+#ifdef UNIT_TESTING_ENABLED
+
 #include "lpc17xx_timer.h"
 #include "test_asserts.h"
 #include "test_utils.h"
 
 void TIMER_RunTests(void);
 
+#endif // UNIT_TESTING_ENABLED
 #endif //LPC17XX_TIMER_TESTS_H

--- a/CMSISv2p00_LPC17xx/Drivers/tests/inc/run_tests.h
+++ b/CMSISv2p00_LPC17xx/Drivers/tests/inc/run_tests.h
@@ -1,6 +1,8 @@
 #ifndef RUN_TESTS_H
 #define RUN_TESTS_H
 
+#ifdef UNIT_TESTING_ENABLED
+
 #include "lpc17xx_pinsel_tests.h"
 #include "lpc17xx_gpio_tests.h"
 #include "lpc17xx_systick_tests.h"
@@ -9,4 +11,5 @@
 
 void run_all_tests(void);
 
+#endif // UNIT_TESTING_ENABLED
 #endif //RUN_TESTS_H

--- a/CMSISv2p00_LPC17xx/Drivers/tests/inc/test_asserts.h
+++ b/CMSISv2p00_LPC17xx/Drivers/tests/inc/test_asserts.h
@@ -1,6 +1,8 @@
 #ifndef TEST_ASSERTS_H
 #define TEST_ASSERTS_H
 
+#ifdef UNIT_TESTING_ENABLED
+
 #include <stdio.h>
 #include <stdbool.h>
 
@@ -40,4 +42,5 @@
         return __test_passed; \
     } while(0)
 
+#endif // UNIT_TESTING_ENABLED
 #endif //TEST_ASSERTS_H

--- a/CMSISv2p00_LPC17xx/Drivers/tests/inc/test_utils.h
+++ b/CMSISv2p00_LPC17xx/Drivers/tests/inc/test_utils.h
@@ -1,6 +1,8 @@
 #ifndef TEST_UTILS_H
 #define TEST_UTILS_H
 
+#ifdef UNIT_TESTING_ENABLED
+
 //==========================================================================
 // Defines for available pins in each port (double register per port).
 //==========================================================================
@@ -74,4 +76,5 @@ do { for (volatile unsigned int _d = 0; _d < 50; ++_d) {}} while(0)
                                 LPC_PINCON->PINMODE5 &= ~(0x3 << (((n) - 16) * 2)); \
                                 for (volatile int _d = 0; _d < 50; ++_d) {}} while(0)
 
+#endif // UNIT_TESTING_ENABLED
 #endif //TEST_UTILS_H

--- a/CMSISv2p00_LPC17xx/Drivers/tests/src/lpc17xx_exti_tests.c
+++ b/CMSISv2p00_LPC17xx/Drivers/tests/src/lpc17xx_exti_tests.c
@@ -4,6 +4,8 @@
  * @version  V1.0
  * @date     11 July 2025
  */
+#ifdef UNIT_TESTING_ENABLED
+
 #include "lpc17xx_exti_tests.h"
 #include "test_utils.h"
 
@@ -150,3 +152,4 @@ uint8_t EXTI_EnableIRQTest(void) {
     ASSERT_TEST();
 }
 
+#endif // UNIT_TESTING_ENABLED

--- a/CMSISv2p00_LPC17xx/Drivers/tests/src/lpc17xx_gpio_tests.c
+++ b/CMSISv2p00_LPC17xx/Drivers/tests/src/lpc17xx_gpio_tests.c
@@ -4,6 +4,8 @@
  * @version  V1.0
  * @date     11 July 2025
  */
+#ifdef UNIT_TESTING_ENABLED
+
 #include "lpc17xx_gpio_tests.h"
 #include "test_utils.h"
 
@@ -566,3 +568,5 @@ uint8_t FIO_ByteSetMaskTest(void) {
 
     ASSERT_TEST();
 }
+
+#endif // UNIT_TESTING_ENABLED

--- a/CMSISv2p00_LPC17xx/Drivers/tests/src/lpc17xx_pinsel_tests.c
+++ b/CMSISv2p00_LPC17xx/Drivers/tests/src/lpc17xx_pinsel_tests.c
@@ -4,6 +4,8 @@
  * @version  V1.0
  * @date     11 July 2025
  */
+#ifdef UNIT_TESTING_ENABLED
+
 #include "lpc17xx_pinsel_tests.h"
 
 static PINSEL_CFG_Type pinCfg = {0};
@@ -133,3 +135,5 @@ uint8_t PINSEL_ConfigMultiplePinsTest(void) {
 
     ASSERT_TEST();
 }
+
+#endif // UNIT_TESTING_ENABLED

--- a/CMSISv2p00_LPC17xx/Drivers/tests/src/lpc17xx_systick_tests.c
+++ b/CMSISv2p00_LPC17xx/Drivers/tests/src/lpc17xx_systick_tests.c
@@ -4,6 +4,8 @@
  * @version  V1.0
  * @date     16 July 2025
  */
+#ifdef UNIT_TESTING_ENABLED
+
 #include "lpc17xx_systick_tests.h"
 
 uint8_t SYSTICK_InternalInitTest();
@@ -209,3 +211,5 @@ uint8_t SYSTICK_HasFiredTest() {
 
     ASSERT_TEST();
 }
+
+#endif // UNIT_TESTING_ENABLED

--- a/CMSISv2p00_LPC17xx/Drivers/tests/src/lpc17xx_timer_tests.c
+++ b/CMSISv2p00_LPC17xx/Drivers/tests/src/lpc17xx_timer_tests.c
@@ -4,6 +4,8 @@
  * @version  V1.0
  * @date     01 August 2025
  */
+#ifdef UNIT_TESTING_ENABLED
+
 #include "lpc17xx_timer_tests.h"
 
 uint8_t TIM_InitTimerTest(void);
@@ -285,3 +287,5 @@ uint8_t TIM_ResetCounterTest(void) {
 
     ASSERT_TEST();
 }
+
+#endif //UNIT_TESTING_ENABLED

--- a/CMSISv2p00_LPC17xx/Drivers/tests/src/run_tests.c
+++ b/CMSISv2p00_LPC17xx/Drivers/tests/src/run_tests.c
@@ -1,3 +1,5 @@
+#ifdef UNIT_TESTING_ENABLED
+
 #include "run_tests.h"
 
 void run_all_tests(void) {
@@ -7,3 +9,5 @@ void run_all_tests(void) {
     EXTI_RunTests();
     TIMER_RunTests();
 }
+
+#endif //UNIT_TESTING_ENABLED


### PR DESCRIPTION
This PR wraps all test-related files and headers with #ifdef UNIT_TESTING_ENABLEDin order to prevent unnecessary compilation of test code in non-testing environments.

This change:

- Avoids semihosting dependencies when tests are not needed
- Keeps the library lightweight for end users
- Enables clean separation between production and test builds

The macro UNIT_TESTING_ENABLEDmust now be defined explicitly in the build settings of the test project.
No changes are required in user/student projects.