### PR TITLE
refactor(uart): unify UART typedef and split drivers

### DIFF
--- a/CMSISv2p00_LPC17xx/Drivers/inc/lpc17xx_uart.h
+++ b/CMSISv2p00_LPC17xx/Drivers/inc/lpc17xx_uart.h
@@ -1,644 +1,721 @@
-/***********************************************************************//**
- * @file        lpc17xx_uart.h
- * @brief        Contains all macro definitions and function prototypes
- *                 support for UART firmware library on LPC17xx
- * @version        3.0
- * @date        18. June. 2010
- * @author        NXP MCU SW Application Team
- **************************************************************************
- * Software that is described herein is for illustrative purposes only
- * which provides customers with programming information regarding the
- * products. This software is supplied "AS IS" without any warranties.
- * NXP Semiconductors assumes no responsibility or liability for the
- * use of the software, conveys no license or title under any patent,
- * copyright, or mask work right to the product. NXP Semiconductors
- * reserves the right to make changes in the software without
- * notification. NXP Semiconductors also make no representation or
- * warranty that such application will be suitable for the specified
- * use without further testing or modification.
- **************************************************************************/
-
-/* Peripheral group ----------------------------------------------------------- */
-/** @defgroup UART UART
- * @ingroup LPC1700CMSIS_FwLib_Drivers
- * @{
- */
-
+//
+//
+//
+//      DO NOT USE
+//      DO NOT USE
+//      DO NOT USE
+//      DO NOT USE
+//      DO NOT USE
+//      DO NOT USE
+//      DO NOT USE
+//      DO NOT USE
+//      DO NOT USE
+//      DO NOT USE
+//      DO NOT USE
+//      DO NOT USE
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+// /***********************************************************************//**
+//  * @file        lpc17xx_uart.h
+//  * @brief        Contains all macro definitions and function prototypes
+//  *                 support for UART firmware library on LPC17xx
+//  * @version        3.0
+//  * @date        18. June. 2010
+//  * @author        NXP MCU SW Application Team
+//  **************************************************************************
+//  * Software that is described herein is for illustrative purposes only
+//  * which provides customers with programming information regarding the
+//  * products. This software is supplied "AS IS" without any warranties.
+//  * NXP Semiconductors assumes no responsibility or liability for the
+//  * use of the software, conveys no license or title under any patent,
+//  * copyright, or mask work right to the product. NXP Semiconductors
+//  * reserves the right to make changes in the software without
+//  * notification. NXP Semiconductors also make no representation or
+//  * warranty that such application will be suitable for the specified
+//  * use without further testing or modification.
+//  **************************************************************************/
+//
+// /* Peripheral group ----------------------------------------------------------- */
+// /** @defgroup UART UART
+//  * @ingroup LPC1700CMSIS_FwLib_Drivers
+//  * @{
+//  */
+//
 #ifndef __LPC17XX_UART_H
 #define __LPC17XX_UART_H
-
-/* Includes ------------------------------------------------------------------- */
-#include "LPC17xx.h"
-#include "lpc_types.h"
-
-
-#ifdef __cplusplus
-extern "C"
-{
-#endif
-
-/* Public Macros -------------------------------------------------------------- */
-/** @defgroup UART_Public_Macros  UART Public Macros
- * @{
- */
-
-/** UART time-out definitions in case of using Read() and Write function
- * with Blocking Flag mode
- */
-#define UART_BLOCKING_TIMEOUT            (0xFFFFFFFFUL)
-
-/**
- * @}
- */
-
-/* Private Macros ------------------------------------------------------------- */
-/** @defgroup UART_Private_Macros UART Private Macros
- * @{
- */
-
-/* Accepted Error baud rate value (in percent unit) */
-#define UART_ACCEPTED_BAUDRATE_ERROR    (3)            /*!< Acceptable UART baudrate error */
-
-
-/* --------------------- BIT DEFINITIONS -------------------------------------- */
-/*********************************************************************//**
- * Macro defines for Macro defines for UARTn Receiver Buffer Register
- **********************************************************************/
-#define UART_RBR_MASKBIT       ((uint8_t)0xFF)         /*!< UART Received Buffer mask bit (8 bits) */
-
-/*********************************************************************//**
- * Macro defines for Macro defines for UARTn Transmit Holding Register
- **********************************************************************/
-#define UART_THR_MASKBIT       ((uint8_t)0xFF)         /*!< UART Transmit Holding mask bit (8 bits) */
-
-/*********************************************************************//**
- * Macro defines for Macro defines for UARTn Divisor Latch LSB register
- **********************************************************************/
-#define UART_LOAD_DLL(div)    ((div) & 0xFF)    /**< Macro for loading least significant halfs of divisors */
-#define UART_DLL_MASKBIT    ((uint8_t)0xFF)    /*!< Divisor latch LSB bit mask */
-
-/*********************************************************************//**
- * Macro defines for Macro defines for UARTn Divisor Latch MSB register
- **********************************************************************/
-#define UART_DLM_MASKBIT    ((uint8_t)0xFF)            /*!< Divisor latch MSB bit mask */
-#define UART_LOAD_DLM(div)  (((div) >> 8) & 0xFF)    /**< Macro for loading most significant halfs of divisors */
-
-/*********************************************************************//**
- * Macro defines for Macro defines for UART interrupt enable register
- **********************************************************************/
-#define UART_IER_RBRINT_EN        ((uint32_t)(1<<0))     /*!< RBR Interrupt enable*/
-#define UART_IER_THREINT_EN        ((uint32_t)(1<<1))     /*!< THR Interrupt enable*/
-#define UART_IER_RLSINT_EN        ((uint32_t)(1<<2))     /*!< RX line status interrupt enable*/
-#define UART1_IER_MSINT_EN        ((uint32_t)(1<<3))    /*!< Modem status interrupt enable */
-#define UART1_IER_CTSINT_EN        ((uint32_t)(1<<7))    /*!< CTS1 signal transition interrupt enable */
-#define UART_IER_ABEOINT_EN        ((uint32_t)(1<<8))     /*!< Enables the end of auto-baud interrupt */
-#define UART_IER_ABTOINT_EN        ((uint32_t)(1<<9))     /*!< Enables the auto-baud time-out interrupt */
-#define UART_IER_BITMASK        ((uint32_t)(0x307)) /*!< UART interrupt enable register bit mask */
-#define UART1_IER_BITMASK        ((uint32_t)(0x38F)) /*!< UART1 interrupt enable register bit mask */
-
-/*********************************************************************//**
- * Macro defines for Macro defines for UART interrupt identification register
- **********************************************************************/
-#define UART_IIR_INTSTAT_PEND    ((uint32_t)(1<<0))    /*!<Interrupt Status - Active low */
-#define UART_IIR_INTID_RLS        ((uint32_t)(3<<1))     /*!<Interrupt identification: Receive line status*/
-#define UART_IIR_INTID_RDA        ((uint32_t)(2<<1))     /*!<Interrupt identification: Receive data available*/
-#define UART_IIR_INTID_CTI        ((uint32_t)(6<<1))     /*!<Interrupt identification: Character time-out indicator*/
-#define UART_IIR_INTID_THRE        ((uint32_t)(1<<1))     /*!<Interrupt identification: THRE interrupt*/
-#define UART1_IIR_INTID_MODEM    ((uint32_t)(0<<1))     /*!<Interrupt identification: Modem interrupt*/
-#define UART_IIR_INTID_MASK        ((uint32_t)(7<<1))    /*!<Interrupt identification: Interrupt ID mask */
-#define UART_IIR_FIFO_EN        ((uint32_t)(3<<6))     /*!<These bits are equivalent to UnFCR[0] */
-#define UART_IIR_ABEO_INT        ((uint32_t)(1<<8))     /*!< End of auto-baud interrupt */
-#define UART_IIR_ABTO_INT        ((uint32_t)(1<<9))     /*!< Auto-baud time-out interrupt */
-#define UART_IIR_BITMASK        ((uint32_t)(0x3CF))    /*!< UART interrupt identification register bit mask */
-
-/*********************************************************************//**
- * Macro defines for Macro defines for UART FIFO control register
- **********************************************************************/
-#define UART_FCR_FIFO_EN        ((uint8_t)(1<<0))     /*!< UART FIFO enable */
-#define UART_FCR_RX_RS            ((uint8_t)(1<<1))     /*!< UART FIFO RX reset */
-#define UART_FCR_TX_RS            ((uint8_t)(1<<2))     /*!< UART FIFO TX reset */
-#define UART_FCR_DMAMODE_SEL     ((uint8_t)(1<<3))     /*!< UART DMA mode selection */
-#define UART_FCR_TRG_LEV0        ((uint8_t)(0))         /*!< UART FIFO trigger level 0: 1 character */
-#define UART_FCR_TRG_LEV1        ((uint8_t)(1<<6))     /*!< UART FIFO trigger level 1: 4 character */
-#define UART_FCR_TRG_LEV2        ((uint8_t)(2<<6))     /*!< UART FIFO trigger level 2: 8 character */
-#define UART_FCR_TRG_LEV3        ((uint8_t)(3<<6))     /*!< UART FIFO trigger level 3: 14 character */
-#define UART_FCR_BITMASK        ((uint8_t)(0xCF))    /*!< UART FIFO control bit mask */
-#define UART_TX_FIFO_SIZE        (16)
-
-/*********************************************************************//**
- * Macro defines for Macro defines for UART line control register
- **********************************************************************/
-#define UART_LCR_WLEN5             ((uint8_t)(0))           /*!< UART 5 bit data mode */
-#define UART_LCR_WLEN6             ((uint8_t)(1<<0))       /*!< UART 6 bit data mode */
-#define UART_LCR_WLEN7             ((uint8_t)(2<<0))       /*!< UART 7 bit data mode */
-#define UART_LCR_WLEN8             ((uint8_t)(3<<0))       /*!< UART 8 bit data mode */
-#define UART_LCR_STOPBIT_SEL    ((uint8_t)(1<<2))       /*!< UART Two Stop Bits Select */
-#define UART_LCR_PARITY_EN        ((uint8_t)(1<<3))        /*!< UART Parity Enable */
-#define UART_LCR_PARITY_ODD        ((uint8_t)(0))             /*!< UART Odd Parity Select */
-#define UART_LCR_PARITY_EVEN    ((uint8_t)(1<<4))        /*!< UART Even Parity Select */
-#define UART_LCR_PARITY_F_1        ((uint8_t)(2<<4))        /*!< UART force 1 stick parity */
-#define UART_LCR_PARITY_F_0        ((uint8_t)(3<<4))        /*!< UART force 0 stick parity */
-#define UART_LCR_BREAK_EN        ((uint8_t)(1<<6))        /*!< UART Transmission Break enable */
-#define UART_LCR_DLAB_EN        ((uint8_t)(1<<7))        /*!< UART Divisor Latches Access bit enable */
-#define UART_LCR_BITMASK        ((uint8_t)(0xFF))        /*!< UART line control bit mask */
-
-/*********************************************************************//**
- * Macro defines for Macro defines for UART1 Modem Control Register
- **********************************************************************/
-#define UART1_MCR_DTR_CTRL        ((uint8_t)(1<<0))        /*!< Source for modem output pin DTR */
-#define UART1_MCR_RTS_CTRL        ((uint8_t)(1<<1))        /*!< Source for modem output pin RTS */
-#define UART1_MCR_LOOPB_EN        ((uint8_t)(1<<4))        /*!< Loop back mode select */
-#define UART1_MCR_AUTO_RTS_EN    ((uint8_t)(1<<6))        /*!< Enable Auto RTS flow-control */
-#define UART1_MCR_AUTO_CTS_EN    ((uint8_t)(1<<7))        /*!< Enable Auto CTS flow-control */
-#define UART1_MCR_BITMASK        ((uint8_t)(0x0F3))        /*!< UART1 bit mask value */
-
-/*********************************************************************//**
- * Macro defines for Macro defines for UART line status register
- **********************************************************************/
-#define UART_LSR_RDR        ((uint8_t)(1<<0))     /*!<Line status register: Receive data ready*/
-#define UART_LSR_OE            ((uint8_t)(1<<1))     /*!<Line status register: Overrun error*/
-#define UART_LSR_PE            ((uint8_t)(1<<2))     /*!<Line status register: Parity error*/
-#define UART_LSR_FE            ((uint8_t)(1<<3))     /*!<Line status register: Framing error*/
-#define UART_LSR_BI            ((uint8_t)(1<<4))     /*!<Line status register: Break interrupt*/
-#define UART_LSR_THRE        ((uint8_t)(1<<5))     /*!<Line status register: Transmit holding register empty*/
-#define UART_LSR_TEMT        ((uint8_t)(1<<6))     /*!<Line status register: Transmitter empty*/
-#define UART_LSR_RXFE        ((uint8_t)(1<<7))     /*!<Error in RX FIFO*/
-#define UART_LSR_BITMASK    ((uint8_t)(0xFF))     /*!<UART Line status bit mask */
-
-/*********************************************************************//**
- * Macro defines for Macro defines for UART Modem (UART1 only) status register
- **********************************************************************/
-#define UART1_MSR_DELTA_CTS        ((uint8_t)(1<<0))    /*!< Set upon state change of input CTS */
-#define UART1_MSR_DELTA_DSR        ((uint8_t)(1<<1))    /*!< Set upon state change of input DSR */
-#define UART1_MSR_LO2HI_RI        ((uint8_t)(1<<2))    /*!< Set upon low to high transition of input RI */
-#define UART1_MSR_DELTA_DCD        ((uint8_t)(1<<3))    /*!< Set upon state change of input DCD */
-#define UART1_MSR_CTS            ((uint8_t)(1<<4))    /*!< Clear To Send State */
-#define UART1_MSR_DSR            ((uint8_t)(1<<5))    /*!< Data Set Ready State */
-#define UART1_MSR_RI            ((uint8_t)(1<<6))    /*!< Ring Indicator State */
-#define UART1_MSR_DCD            ((uint8_t)(1<<7))    /*!< Data Carrier Detect State */
-#define UART1_MSR_BITMASK        ((uint8_t)(0xFF))    /*!< MSR register bit-mask value */
-
-/*********************************************************************//**
- * Macro defines for Macro defines for UART Scratch Pad Register
- **********************************************************************/
-#define UART_SCR_BIMASK        ((uint8_t)(0xFF))    /*!< UART Scratch Pad bit mask */
-
-/*********************************************************************//**
- * Macro defines for Macro defines for UART Auto baudrate control register
- **********************************************************************/
-#define UART_ACR_START                ((uint32_t)(1<<0))    /**< UART Auto-baud start */
-#define UART_ACR_MODE                ((uint32_t)(1<<1))    /**< UART Auto baudrate Mode 1 */
-#define UART_ACR_AUTO_RESTART        ((uint32_t)(1<<2))    /**< UART Auto baudrate restart */
-#define UART_ACR_ABEOINT_CLR        ((uint32_t)(1<<8))    /**< UART End of auto-baud interrupt clear */
-#define UART_ACR_ABTOINT_CLR        ((uint32_t)(1<<9))    /**< UART Auto-baud time-out interrupt clear */
-#define UART_ACR_BITMASK            ((uint32_t)(0x307))    /**< UART Auto Baudrate register bit mask */
-
-/*********************************************************************//**
- * Macro defines for Macro defines for UART IrDA control register
- **********************************************************************/
-#define UART_ICR_IRDAEN            ((uint32_t)(1<<0))            /**< IrDA mode enable */
-#define UART_ICR_IRDAINV        ((uint32_t)(1<<1))            /**< IrDA serial input inverted */
-#define UART_ICR_FIXPULSE_EN    ((uint32_t)(1<<2))            /**< IrDA fixed pulse width mode */
-#define UART_ICR_PULSEDIV(n)    ((uint32_t)((n&0x07)<<3))    /**< PulseDiv - Configures the pulse when FixPulseEn = 1 */
-#define UART_ICR_BITMASK        ((uint32_t)(0x3F))            /*!< UART IRDA bit mask */
-
-/*********************************************************************//**
- * Macro defines for Macro defines for UART Fractional divider register
- **********************************************************************/
-#define UART_FDR_DIVADDVAL(n)    ((uint32_t)(n&0x0F))        /**< Baud-rate generation pre-scaler divisor */
-#define UART_FDR_MULVAL(n)        ((uint32_t)((n<<4)&0xF0))    /**< Baud-rate pre-scaler multiplier value */
-#define UART_FDR_BITMASK        ((uint32_t)(0xFF))            /**< UART Fractional Divider register bit mask */
-
-/*********************************************************************//**
- * Macro defines for Macro defines for UART Tx Enable register
- **********************************************************************/
-#define UART_TER_TXEN            ((uint8_t)(1<<7))         /*!< Transmit enable bit */
-#define UART_TER_BITMASK        ((uint8_t)(0x80))        /**< UART Transmit Enable Register bit mask */
-
-/*********************************************************************//**
- * Macro defines for Macro defines for UART1 RS485 Control register
- **********************************************************************/
-#define UART1_RS485CTRL_NMM_EN        ((uint32_t)(1<<0))    /*!< RS-485/EIA-485 Normal Multi-drop Mode (NMM)
-                                                        is disabled */
-#define UART1_RS485CTRL_RX_DIS        ((uint32_t)(1<<1))    /*!< The receiver is disabled */
-#define UART1_RS485CTRL_AADEN        ((uint32_t)(1<<2))    /*!< Auto Address Detect (AAD) is enabled */
-#define UART1_RS485CTRL_SEL_DTR        ((uint32_t)(1<<3))    /*!< If direction control is enabled
-                                                        (bit DCTRL = 1), pin DTR is used for direction control */
-#define UART1_RS485CTRL_DCTRL_EN    ((uint32_t)(1<<4))    /*!< Enable Auto Direction Control */
-#define UART1_RS485CTRL_OINV_1        ((uint32_t)(1<<5))    /*!< This bit reverses the polarity of the direction
-                                                        control signal on the RTS (or DTR) pin. The direction control pin
-                                                        will be driven to logic "1" when the transmitter has data to be sent */
-#define UART1_RS485CTRL_BITMASK        ((uint32_t)(0x3F))    /**< RS485 control bit-mask value */
-
-/*********************************************************************//**
- * Macro defines for Macro defines for UART1 RS-485 Address Match register
- **********************************************************************/
-#define UART1_RS485ADRMATCH_BITMASK ((uint8_t)(0xFF))     /**< Bit mask value */
-
-/*********************************************************************//**
- * Macro defines for Macro defines for UART1 RS-485 Delay value register
- **********************************************************************/
-/* Macro defines for UART1 RS-485 Delay value register */
-#define UART1_RS485DLY_BITMASK        ((uint8_t)(0xFF))     /** Bit mask value */
-
-/*********************************************************************//**
- * Macro defines for Macro defines for UART FIFO Level register
- **********************************************************************/
-#define UART_FIFOLVL_RXFIFOLVL(n)    ((uint32_t)(n&0x0F))        /**< Reflects the current level of the UART receiver FIFO */
-#define UART_FIFOLVL_TXFIFOLVL(n)    ((uint32_t)((n>>8)&0x0F))    /**< Reflects the current level of the UART transmitter FIFO */
-#define UART_FIFOLVL_BITMASK        ((uint32_t)(0x0F0F))        /**< UART FIFO Level Register bit mask */
-
-
-/* ---------------- CHECK PARAMETER DEFINITIONS ---------------------------- */
-
-/** Macro to check the input UART_DATABIT parameters */
-#define PARAM_UART_DATABIT(databit)    ((databit==UART_DATABIT_5) || (databit==UART_DATABIT_6)\
-|| (databit==UART_DATABIT_7) || (databit==UART_DATABIT_8))
-
-/** Macro to check the input UART_STOPBIT parameters */
-#define PARAM_UART_STOPBIT(stopbit)    ((stopbit==UART_STOPBIT_1) || (stopbit==UART_STOPBIT_2))
-
-/** Macro to check the input UART_PARITY parameters */
-#define PARAM_UART_PARITY(parity)    ((parity==UART_PARITY_NONE) || (parity==UART_PARITY_ODD) \
-|| (parity==UART_PARITY_EVEN) || (parity==UART_PARITY_SP_1) \
-|| (parity==UART_PARITY_SP_0))
-
-/** Macro to check the input UART_FIFO parameters */
-#define PARAM_UART_FIFO_LEVEL(fifo)    ((fifo==UART_FIFO_TRGLEV0) \
-|| (fifo==UART_FIFO_TRGLEV1) || (fifo==UART_FIFO_TRGLEV2) \
-|| (fifo==UART_FIFO_TRGLEV3))
-
-/** Macro to check the input UART_INTCFG parameters */
-#define PARAM_UART_INTCFG(IntCfg)    ((IntCfg==UART_INTCFG_RBR) || (IntCfg==UART_INTCFG_THRE) \
-|| (IntCfg==UART_INTCFG_RLS) || (IntCfg==UART_INTCFG_ABEO) \
-|| (IntCfg==UART_INTCFG_ABTO))
-
-/** Macro to check the input UART1_INTCFG parameters - expansion input parameter for UART1 */
-#define PARAM_UART1_INTCFG(IntCfg)    ((IntCfg==UART1_INTCFG_MS) || (IntCfg==UART1_INTCFG_CTS))
-
-/** Macro to check the input UART_AUTOBAUD_MODE parameters */
-#define PARAM_UART_AUTOBAUD_MODE(ABmode)    ((ABmode==UART_AUTOBAUD_MODE0) || (ABmode==UART_AUTOBAUD_MODE1))
-
-/** Macro to check the input UART_AUTOBAUD_INTSTAT parameters */
-#define PARAM_UART_AUTOBAUD_INTSTAT(ABIntStat)    ((ABIntStat==UART_AUTOBAUD_INTSTAT_ABEO) || \
-        (ABIntStat==UART_AUTOBAUD_INTSTAT_ABTO))
-
-/** Macro to check the input UART_IrDA_PULSEDIV parameters */
-#define PARAM_UART_IrDA_PULSEDIV(PulseDiv)    ((PulseDiv==UART_IrDA_PULSEDIV2) || (PulseDiv==UART_IrDA_PULSEDIV4) \
-|| (PulseDiv==UART_IrDA_PULSEDIV8) || (PulseDiv==UART_IrDA_PULSEDIV16) \
-|| (PulseDiv==UART_IrDA_PULSEDIV32) || (PulseDiv==UART_IrDA_PULSEDIV64) \
-|| (PulseDiv==UART_IrDA_PULSEDIV128) || (PulseDiv==UART_IrDA_PULSEDIV256))
-
-/* Macro to check the input UART1_SignalState parameters */
-#define PARAM_UART1_SIGNALSTATE(x) ((x==INACTIVE) || (x==ACTIVE))
-
-/** Macro to check the input PARAM_UART1_MODEM_PIN parameters */
-#define PARAM_UART1_MODEM_PIN(x) ((x==UART1_MODEM_PIN_DTR) || (x==UART1_MODEM_PIN_RTS))
-
-/** Macro to check the input PARAM_UART1_MODEM_MODE parameters */
-#define PARAM_UART1_MODEM_MODE(x) ((x==UART1_MODEM_MODE_LOOPBACK) || (x==UART1_MODEM_MODE_AUTO_RTS) \
-|| (x==UART1_MODEM_MODE_AUTO_CTS))
-
-/** Macro to check the direction control pin type */
-#define PARAM_UART_RS485_DIRCTRL_PIN(x)    ((x==UART1_RS485_DIRCTRL_RTS) || (x==UART1_RS485_DIRCTRL_DTR))
-
-/* Macro to determine if it is valid UART port number */
-#define PARAM_UARTx(x)    ((((uint32_t *)x)==((uint32_t *)LPC_UART0)) \
-|| (((uint32_t *)x)==((uint32_t *)LPC_UART1)) \
-|| (((uint32_t *)x)==((uint32_t *)LPC_UART2)) \
-|| (((uint32_t *)x)==((uint32_t *)LPC_UART3)))
-#define PARAM_UART_IrDA(x) (((uint32_t *)x)==((uint32_t *)LPC_UART3))
-#define PARAM_UART1_MODEM(x) (((uint32_t *)x)==((uint32_t *)LPC_UART1))
-
-/** Macro to check the input value for UART1_RS485_CFG_MATCHADDRVALUE parameter */
-#define PARAM_UART1_RS485_CFG_MATCHADDRVALUE(x) ((x<0xFF))
-
-/** Macro to check the input value for UART1_RS485_CFG_DELAYVALUE parameter */
-#define PARAM_UART1_RS485_CFG_DELAYVALUE(x) ((x<0xFF))
-
-/**
- * @}
- */
-
-
-/* Public Types --------------------------------------------------------------- */
-/** @defgroup UART_Public_Types UART Public Types
- * @{
- */
-
-/**
- * @brief UART Databit type definitions
- */
-typedef enum {
-    UART_DATABIT_5        = 0,             /*!< UART 5 bit data mode */
-    UART_DATABIT_6,                         /*!< UART 6 bit data mode */
-    UART_DATABIT_7,                         /*!< UART 7 bit data mode */
-    UART_DATABIT_8                         /*!< UART 8 bit data mode */
-} UART_DATABIT_Type;
-
-/**
- * @brief UART Stop bit type definitions
- */
-typedef enum {
-    UART_STOPBIT_1        = (0),                       /*!< UART 1 Stop Bits Select */
-    UART_STOPBIT_2,                                     /*!< UART Two Stop Bits Select */
-} UART_STOPBIT_Type;
-
-/**
- * @brief UART Parity type definitions
- */
-typedef enum {
-    UART_PARITY_NONE     = 0,                    /*!< No parity */
-    UART_PARITY_ODD,                             /*!< Odd parity */
-    UART_PARITY_EVEN,                             /*!< Even parity */
-    UART_PARITY_SP_1,                             /*!< Forced "1" stick parity */
-    UART_PARITY_SP_0                             /*!< Forced "0" stick parity */
-} UART_PARITY_Type;
-
-/**
- * @brief FIFO Level type definitions
- */
-typedef enum {
-    UART_FIFO_TRGLEV0 = 0,    /*!< UART FIFO trigger level 0: 1 character */
-    UART_FIFO_TRGLEV1,         /*!< UART FIFO trigger level 1: 4 character */
-    UART_FIFO_TRGLEV2,        /*!< UART FIFO trigger level 2: 8 character */
-    UART_FIFO_TRGLEV3        /*!< UART FIFO trigger level 3: 14 character */
-} UART_FITO_LEVEL_Type;
-
-/********************************************************************//**
-* @brief UART Interrupt Type definitions
-**********************************************************************/
-typedef enum {
-    UART_INTCFG_RBR = 0,    /*!< RBR Interrupt enable*/
-    UART_INTCFG_THRE,        /*!< THR Interrupt enable*/
-    UART_INTCFG_RLS,        /*!< RX line status interrupt enable*/
-    UART1_INTCFG_MS,        /*!< Modem status interrupt enable (UART1 only) */
-    UART1_INTCFG_CTS,        /*!< CTS1 signal transition interrupt enable (UART1 only) */
-    UART_INTCFG_ABEO,        /*!< Enables the end of auto-baud interrupt */
-    UART_INTCFG_ABTO        /*!< Enables the auto-baud time-out interrupt */
-} UART_INT_Type;
-
-/**
- * @brief UART Line Status Type definition
- */
-typedef enum {
-    UART_LINESTAT_RDR    = UART_LSR_RDR,            /*!<Line status register: Receive data ready*/
-    UART_LINESTAT_OE    = UART_LSR_OE,            /*!<Line status register: Overrun error*/
-    UART_LINESTAT_PE    = UART_LSR_PE,            /*!<Line status register: Parity error*/
-    UART_LINESTAT_FE    = UART_LSR_FE,            /*!<Line status register: Framing error*/
-    UART_LINESTAT_BI    = UART_LSR_BI,            /*!<Line status register: Break interrupt*/
-    UART_LINESTAT_THRE    = UART_LSR_THRE,        /*!<Line status register: Transmit holding register empty*/
-    UART_LINESTAT_TEMT    = UART_LSR_TEMT,        /*!<Line status register: Transmitter empty*/
-    UART_LINESTAT_RXFE    = UART_LSR_RXFE            /*!<Error in RX FIFO*/
-} UART_LS_Type;
-
-/**
- * @brief UART Auto-baudrate mode type definition
- */
-typedef enum {
-    UART_AUTOBAUD_MODE0                = 0,            /**< UART Auto baudrate Mode 0 */
-    UART_AUTOBAUD_MODE1,                            /**< UART Auto baudrate Mode 1 */
-} UART_AB_MODE_Type;
-
-/**
- * @brief Auto Baudrate mode configuration type definition
- */
-typedef struct {
-    UART_AB_MODE_Type    ABMode;            /**< Autobaudrate mode */
-    FunctionalState        AutoRestart;    /**< Auto Restart state */
-} UART_AB_CFG_Type;
-
-/**
- * @brief UART End of Auto-baudrate type definition
- */
-typedef enum {
-    UART_AUTOBAUD_INTSTAT_ABEO        = UART_IIR_ABEO_INT,        /**< UART End of auto-baud interrupt  */
-    UART_AUTOBAUD_INTSTAT_ABTO        = UART_IIR_ABTO_INT            /**< UART Auto-baud time-out interrupt  */
-}UART_ABEO_Type;
-
-/**
- * UART IrDA Control type Definition
- */
-typedef enum {
-    UART_IrDA_PULSEDIV2        = 0,        /**< Pulse width = 2 * Tpclk
-                                        - Configures the pulse when FixPulseEn = 1 */
-    UART_IrDA_PULSEDIV4,                /**< Pulse width = 4 * Tpclk
-                                        - Configures the pulse when FixPulseEn = 1 */
-    UART_IrDA_PULSEDIV8,                /**< Pulse width = 8 * Tpclk
-                                        - Configures the pulse when FixPulseEn = 1 */
-    UART_IrDA_PULSEDIV16,                /**< Pulse width = 16 * Tpclk
-                                        - Configures the pulse when FixPulseEn = 1 */
-    UART_IrDA_PULSEDIV32,                /**< Pulse width = 32 * Tpclk
-                                        - Configures the pulse when FixPulseEn = 1 */
-    UART_IrDA_PULSEDIV64,                /**< Pulse width = 64 * Tpclk
-                                        - Configures the pulse when FixPulseEn = 1 */
-    UART_IrDA_PULSEDIV128,                /**< Pulse width = 128 * Tpclk
-                                        - Configures the pulse when FixPulseEn = 1 */
-    UART_IrDA_PULSEDIV256                /**< Pulse width = 256 * Tpclk
-                                        - Configures the pulse when FixPulseEn = 1 */
-} UART_IrDA_PULSE_Type;
-
-/********************************************************************//**
-* @brief UART1 Full modem -  Signal states definition
-**********************************************************************/
-typedef enum {
-    INACTIVE = 0,            /* In-active state */
-    ACTIVE = !INACTIVE         /* Active state */
-}UART1_SignalState;
-
-/**
- * @brief UART modem status type definition
- */
-typedef enum {
-    UART1_MODEM_STAT_DELTA_CTS    = UART1_MSR_DELTA_CTS,        /*!< Set upon state change of input CTS */
-    UART1_MODEM_STAT_DELTA_DSR    = UART1_MSR_DELTA_DSR,        /*!< Set upon state change of input DSR */
-    UART1_MODEM_STAT_LO2HI_RI    = UART1_MSR_LO2HI_RI,        /*!< Set upon low to high transition of input RI */
-    UART1_MODEM_STAT_DELTA_DCD    = UART1_MSR_DELTA_DCD,        /*!< Set upon state change of input DCD */
-    UART1_MODEM_STAT_CTS        = UART1_MSR_CTS,            /*!< Clear To Send State */
-    UART1_MODEM_STAT_DSR        = UART1_MSR_DSR,            /*!< Data Set Ready State */
-    UART1_MODEM_STAT_RI            = UART1_MSR_RI,                /*!< Ring Indicator State */
-    UART1_MODEM_STAT_DCD        = UART1_MSR_DCD                /*!< Data Carrier Detect State */
-} UART_MODEM_STAT_type;
-
-/**
- * @brief Modem output pin type definition
- */
-typedef enum {
-    UART1_MODEM_PIN_DTR            = 0,        /*!< Source for modem output pin DTR */
-    UART1_MODEM_PIN_RTS                        /*!< Source for modem output pin RTS */
-} UART_MODEM_PIN_Type;
-
-/**
- * @brief UART Modem mode type definition
- */
-typedef enum {
-    UART1_MODEM_MODE_LOOPBACK    = 0,        /*!< Loop back mode select */
-    UART1_MODEM_MODE_AUTO_RTS,                /*!< Enable Auto RTS flow-control */
-    UART1_MODEM_MODE_AUTO_CTS                 /*!< Enable Auto CTS flow-control */
-} UART_MODEM_MODE_Type;
-
-/**
- * @brief UART Direction Control Pin type definition
- */
-typedef enum {
-    UART1_RS485_DIRCTRL_RTS = 0,    /**< Pin RTS is used for direction control */
-    UART1_RS485_DIRCTRL_DTR            /**< Pin DTR is used for direction control */
-} UART_RS485_DIRCTRL_PIN_Type;
-
-/********************************************************************//**
-* @brief UART Configuration Structure definition
-**********************************************************************/
-typedef struct {
-  uint32_t Baud_rate;           /**< UART baud rate */
-  UART_PARITY_Type Parity;        /**< Parity selection, should be:
-                               - UART_PARITY_NONE: No parity
-                               - UART_PARITY_ODD: Odd parity
-                               - UART_PARITY_EVEN: Even parity
-                               - UART_PARITY_SP_1: Forced "1" stick parity
-                               - UART_PARITY_SP_0: Forced "0" stick parity
-                               */
-  UART_DATABIT_Type Databits;   /**< Number of data bits, should be:
-                               - UART_DATABIT_5: UART 5 bit data mode
-                               - UART_DATABIT_6: UART 6 bit data mode
-                               - UART_DATABIT_7: UART 7 bit data mode
-                               - UART_DATABIT_8: UART 8 bit data mode
-                               */
-  UART_STOPBIT_Type Stopbits;   /**< Number of stop bits, should be:
-                               - UART_STOPBIT_1: UART 1 Stop Bits Select
-                               - UART_STOPBIT_2: UART 2 Stop Bits Select
-                               */
-} UART_CFG_Type;
-
-/********************************************************************//**
-* @brief UART FIFO Configuration Structure definition
-**********************************************************************/
-
-typedef struct {
-    FunctionalState FIFO_ResetRxBuf;    /**< Reset Rx FIFO command state , should be:
-                                         - ENABLE: Reset Rx FIFO in UART
-                                         - DISABLE: Do not reset Rx FIFO  in UART
-                                         */
-    FunctionalState FIFO_ResetTxBuf;    /**< Reset Tx FIFO command state , should be:
-                                         - ENABLE: Reset Tx FIFO in UART
-                                         - DISABLE: Do not reset Tx FIFO  in UART
-                                         */
-    FunctionalState FIFO_DMAMode;        /**< DMA mode, should be:
-                                         - ENABLE: Enable DMA mode in UART
-                                         - DISABLE: Disable DMA mode in UART
-                                         */
-    UART_FITO_LEVEL_Type FIFO_Level;    /**< Rx FIFO trigger level, should be:
-                                        - UART_FIFO_TRGLEV0: UART FIFO trigger level 0: 1 character
-                                        - UART_FIFO_TRGLEV1: UART FIFO trigger level 1: 4 character
-                                        - UART_FIFO_TRGLEV2: UART FIFO trigger level 2: 8 character
-                                        - UART_FIFO_TRGLEV3: UART FIFO trigger level 3: 14 character
-                                        */
-} UART_FIFO_CFG_Type;
-
-/********************************************************************//**
-* @brief UART1 Full modem -  RS485 Control configuration type
-**********************************************************************/
-typedef struct {
-    FunctionalState NormalMultiDropMode_State; /*!< Normal MultiDrop mode State:
-                                                    - ENABLE: Enable this function.
-                                                    - DISABLE: Disable this function. */
-    FunctionalState Rx_State;                    /*!< Receiver State:
-                                                    - ENABLE: Enable Receiver.
-                                                    - DISABLE: Disable Receiver. */
-    FunctionalState AutoAddrDetect_State;        /*!< Auto Address Detect mode state:
-                                                - ENABLE: ENABLE this function.
-                                                - DISABLE: Disable this function. */
-    FunctionalState AutoDirCtrl_State;            /*!< Auto Direction Control State:
-                                                - ENABLE: Enable this function.
-                                                - DISABLE: Disable this function. */
-    UART_RS485_DIRCTRL_PIN_Type DirCtrlPin;        /*!< If direction control is enabled, state:
-                                                - UART1_RS485_DIRCTRL_RTS:
-                                                pin RTS is used for direction control.
-                                                - UART1_RS485_DIRCTRL_DTR:
-                                                pin DTR is used for direction control. */
-     SetState DirCtrlPol_Level;                    /*!< Polarity of the direction control signal on
-                                                the RTS (or DTR) pin:
-                                                - RESET: The direction control pin will be driven
-                                                to logic "0" when the transmitter has data to be sent.
-                                                - SET: The direction control pin will be driven
-                                                to logic "1" when the transmitter has data to be sent. */
-    uint8_t MatchAddrValue;                    /*!< address match value for RS-485/EIA-485 mode, 8-bit long */
-    uint8_t DelayValue;                        /*!< delay time is in periods of the baud clock, 8-bit long */
-} UART1_RS485_CTRLCFG_Type;
-
-/**
- * @}
- */
-
-
-/* Public Functions ----------------------------------------------------------- */
-/** @defgroup UART_Public_Functions UART Public Functions
- * @{
- */
-/* UART Init/DeInit functions --------------------------------------------------*/
-void UART_Init(LPC_UART_TypeDef *UARTx, UART_CFG_Type *UART_ConfigStruct);
-void UART_DeInit(LPC_UART_TypeDef* UARTx);
-void UART_ConfigStructInit(UART_CFG_Type *UART_InitStruct);
-
-/* UART Send/Receive functions -------------------------------------------------*/
-void UART_SendByte(LPC_UART_TypeDef* UARTx, uint8_t Data);
-uint8_t UART_ReceiveByte(LPC_UART_TypeDef* UARTx);
-uint32_t UART_Send(LPC_UART_TypeDef *UARTx, uint8_t *txbuf,
-        uint32_t buflen, TRANSFER_BLOCK_Type flag);
-uint32_t UART_Receive(LPC_UART_TypeDef *UARTx, uint8_t *rxbuf, \
-        uint32_t buflen, TRANSFER_BLOCK_Type flag);
-
-/* UART FIFO functions ----------------------------------------------------------*/
-void UART_FIFOConfig(LPC_UART_TypeDef *UARTx, UART_FIFO_CFG_Type *FIFOCfg);
-void UART_FIFOConfigStructInit(UART_FIFO_CFG_Type *UART_FIFOInitStruct);
-
-/* UART get information functions -----------------------------------------------*/
-uint32_t UART_GetIntId(LPC_UART_TypeDef* UARTx);
-uint8_t UART_GetLineStatus(LPC_UART_TypeDef* UARTx);
-
-/* UART operate functions -------------------------------------------------------*/
-void UART_IntConfig(LPC_UART_TypeDef *UARTx, UART_INT_Type UARTIntCfg, \
-                FunctionalState NewState);
-void UART_TxCmd(LPC_UART_TypeDef *UARTx, FunctionalState NewState);
-FlagStatus UART_CheckBusy(LPC_UART_TypeDef *UARTx);
-void UART_ForceBreak(LPC_UART_TypeDef* UARTx);
-
-/* UART Auto-baud functions -----------------------------------------------------*/
-void UART_ABClearIntPending(LPC_UART_TypeDef *UARTx, UART_ABEO_Type ABIntType);
-void UART_ABCmd(LPC_UART_TypeDef *UARTx, UART_AB_CFG_Type *ABConfigStruct, \
-                FunctionalState NewState);
-
-/* UART1 FullModem functions ----------------------------------------------------*/
-void UART_FullModemForcePinState(LPC_UART1_TypeDef *UARTx, UART_MODEM_PIN_Type Pin, \
-                            UART1_SignalState NewState);
-void UART_FullModemConfigMode(LPC_UART1_TypeDef *UARTx, UART_MODEM_MODE_Type Mode, \
-                            FunctionalState NewState);
-uint8_t UART_FullModemGetStatus(LPC_UART1_TypeDef *UARTx);
-
-/* UART RS485 functions ----------------------------------------------------------*/
-void UART_RS485Config(LPC_UART1_TypeDef *UARTx, \
-        UART1_RS485_CTRLCFG_Type *RS485ConfigStruct);
-void UART_RS485ReceiverCmd(LPC_UART1_TypeDef *UARTx, FunctionalState NewState);
-void UART_RS485SendSlvAddr(LPC_UART1_TypeDef *UARTx, uint8_t SlvAddr);
-uint32_t UART_RS485SendData(LPC_UART1_TypeDef *UARTx, uint8_t *pData, uint32_t size);
-
-/* UART IrDA functions-------------------------------------------------------------*/
-void UART_IrDAInvtInputCmd(LPC_UART_TypeDef* UARTx, FunctionalState NewState);
-void UART_IrDACmd(LPC_UART_TypeDef* UARTx, FunctionalState NewState);
-void UART_IrDAPulseDivConfig(LPC_UART_TypeDef *UARTx, UART_IrDA_PULSE_Type PulseDiv);
-/**
- * @}
- */
-
-
-#ifdef __cplusplus
-}
-#endif
-
-
+//
+// /* Includes ------------------------------------------------------------------- */
+// #include "LPC17xx.h"
+// #include "lpc_types.h"
+//
+//
+// #ifdef __cplusplus
+// extern "C"
+// {
+// #endif
+//
+// /* Public Macros -------------------------------------------------------------- */
+// /** @defgroup UART_Public_Macros  UART Public Macros
+//  * @{
+//  */
+//
+// /** UART time-out definitions in case of using Read() and Write function
+//  * with Blocking Flag mode
+//  */
+// #define UART_BLOCKING_TIMEOUT            (0xFFFFFFFFUL)
+//
+// /**
+//  * @}
+//  */
+//
+// /* Private Macros ------------------------------------------------------------- */
+// /** @defgroup UART_Private_Macros UART Private Macros
+//  * @{
+//  */
+//
+// /* Accepted Error baud rate value (in percent unit) */
+// #define UART_ACCEPTED_BAUDRATE_ERROR    (3)            /*!< Acceptable UART baudrate error */
+//
+//
+// /* --------------------- BIT DEFINITIONS -------------------------------------- */
+// /*********************************************************************//**
+//  * Macro defines for Macro defines for UARTn Receiver Buffer Register
+//  **********************************************************************/
+// #define UART_RBR_MASKBIT       ((uint8_t)0xFF)         /*!< UART Received Buffer mask bit (8 bits) */
+//
+// /*********************************************************************//**
+//  * Macro defines for Macro defines for UARTn Transmit Holding Register
+//  **********************************************************************/
+// #define UART_THR_MASKBIT       ((uint8_t)0xFF)         /*!< UART Transmit Holding mask bit (8 bits) */
+//
+// /*********************************************************************//**
+//  * Macro defines for Macro defines for UARTn Divisor Latch LSB register
+//  **********************************************************************/
+// #define UART_LOAD_DLL(div)    ((div) & 0xFF)    /**< Macro for loading least significant halfs of divisors */
+// #define UART_DLL_MASKBIT    ((uint8_t)0xFF)    /*!< Divisor latch LSB bit mask */
+//
+// /*********************************************************************//**
+//  * Macro defines for Macro defines for UARTn Divisor Latch MSB register
+//  **********************************************************************/
+// #define UART_DLM_MASKBIT    ((uint8_t)0xFF)            /*!< Divisor latch MSB bit mask */
+// #define UART_LOAD_DLM(div)  (((div) >> 8) & 0xFF)    /**< Macro for loading most significant halfs of divisors */
+//
+// /*********************************************************************//**
+//  * Macro defines for Macro defines for UART interrupt enable register
+//  **********************************************************************/
+// #define UART_IER_RBRINT_EN        ((uint32_t)(1<<0))     /*!< RBR Interrupt enable*/
+// #define UART_IER_THREINT_EN        ((uint32_t)(1<<1))     /*!< THR Interrupt enable*/
+// #define UART_IER_RLSINT_EN        ((uint32_t)(1<<2))     /*!< RX line status interrupt enable*/
+// #define UART1_IER_MSINT_EN        ((uint32_t)(1<<3))    /*!< Modem status interrupt enable */
+// #define UART1_IER_CTSINT_EN        ((uint32_t)(1<<7))    /*!< CTS1 signal transition interrupt enable */
+// #define UART_IER_ABEOINT_EN        ((uint32_t)(1<<8))     /*!< Enables the end of auto-baud interrupt */
+// #define UART_IER_ABTOINT_EN        ((uint32_t)(1<<9))     /*!< Enables the auto-baud time-out interrupt */
+// #define UART_IER_BITMASK        ((uint32_t)(0x307)) /*!< UART interrupt enable register bit mask */
+// #define UART1_IER_BITMASK        ((uint32_t)(0x38F)) /*!< UART1 interrupt enable register bit mask */
+//
+// /*********************************************************************//**
+//  * Macro defines for Macro defines for UART interrupt identification register
+//  **********************************************************************/
+// #define UART_IIR_INTSTAT_PEND    ((uint32_t)(1<<0))    /*!<Interrupt Status - Active low */
+// #define UART_IIR_INTID_RLS        ((uint32_t)(3<<1))     /*!<Interrupt identification: Receive line status*/
+// #define UART_IIR_INTID_RDA        ((uint32_t)(2<<1))     /*!<Interrupt identification: Receive data available*/
+// #define UART_IIR_INTID_CTI        ((uint32_t)(6<<1))     /*!<Interrupt identification: Character time-out indicator*/
+// #define UART_IIR_INTID_THRE        ((uint32_t)(1<<1))     /*!<Interrupt identification: THRE interrupt*/
+// #define UART1_IIR_INTID_MODEM    ((uint32_t)(0<<1))     /*!<Interrupt identification: Modem interrupt*/
+// #define UART_IIR_INTID_MASK        ((uint32_t)(7<<1))    /*!<Interrupt identification: Interrupt ID mask */
+// #define UART_IIR_FIFO_EN        ((uint32_t)(3<<6))     /*!<These bits are equivalent to UnFCR[0] */
+// #define UART_IIR_ABEO_INT        ((uint32_t)(1<<8))     /*!< End of auto-baud interrupt */
+// #define UART_IIR_ABTO_INT        ((uint32_t)(1<<9))     /*!< Auto-baud time-out interrupt */
+// #define UART_IIR_BITMASK        ((uint32_t)(0x3CF))    /*!< UART interrupt identification register bit mask */
+//
+// /*********************************************************************//**
+//  * Macro defines for Macro defines for UART FIFO control register
+//  **********************************************************************/
+// #define UART_FCR_FIFO_EN        ((uint8_t)(1<<0))     /*!< UART FIFO enable */
+// #define UART_FCR_RX_RS            ((uint8_t)(1<<1))     /*!< UART FIFO RX reset */
+// #define UART_FCR_TX_RS            ((uint8_t)(1<<2))     /*!< UART FIFO TX reset */
+// #define UART_FCR_DMAMODE_SEL     ((uint8_t)(1<<3))     /*!< UART DMA mode selection */
+// #define UART_FCR_TRG_LEV0        ((uint8_t)(0))         /*!< UART FIFO trigger level 0: 1 character */
+// #define UART_FCR_TRG_LEV1        ((uint8_t)(1<<6))     /*!< UART FIFO trigger level 1: 4 character */
+// #define UART_FCR_TRG_LEV2        ((uint8_t)(2<<6))     /*!< UART FIFO trigger level 2: 8 character */
+// #define UART_FCR_TRG_LEV3        ((uint8_t)(3<<6))     /*!< UART FIFO trigger level 3: 14 character */
+// #define UART_FCR_BITMASK        ((uint8_t)(0xCF))    /*!< UART FIFO control bit mask */
+// #define UART_TX_FIFO_SIZE        (16)
+//
+// /*********************************************************************//**
+//  * Macro defines for Macro defines for UART line control register
+//  **********************************************************************/
+// #define UART_LCR_WLEN5             ((uint8_t)(0))           /*!< UART 5 bit data mode */
+// #define UART_LCR_WLEN6             ((uint8_t)(1<<0))       /*!< UART 6 bit data mode */
+// #define UART_LCR_WLEN7             ((uint8_t)(2<<0))       /*!< UART 7 bit data mode */
+// #define UART_LCR_WLEN8             ((uint8_t)(3<<0))       /*!< UART 8 bit data mode */
+// #define UART_LCR_STOPBIT_SEL    ((uint8_t)(1<<2))       /*!< UART Two Stop Bits Select */
+// #define UART_LCR_PARITY_EN        ((uint8_t)(1<<3))        /*!< UART Parity Enable */
+// #define UART_LCR_PARITY_ODD        ((uint8_t)(0))             /*!< UART Odd Parity Select */
+// #define UART_LCR_PARITY_EVEN    ((uint8_t)(1<<4))        /*!< UART Even Parity Select */
+// #define UART_LCR_PARITY_F_1        ((uint8_t)(2<<4))        /*!< UART force 1 stick parity */
+// #define UART_LCR_PARITY_F_0        ((uint8_t)(3<<4))        /*!< UART force 0 stick parity */
+// #define UART_LCR_BREAK_EN        ((uint8_t)(1<<6))        /*!< UART Transmission Break enable */
+// #define UART_LCR_DLAB_EN        ((uint8_t)(1<<7))        /*!< UART Divisor Latches Access bit enable */
+// #define UART_LCR_BITMASK        ((uint8_t)(0xFF))        /*!< UART line control bit mask */
+//
+// /*********************************************************************//**
+//  * Macro defines for Macro defines for UART1 Modem Control Register
+//  **********************************************************************/
+// #define UART1_MCR_DTR_CTRL        ((uint8_t)(1<<0))        /*!< Source for modem output pin DTR */
+// #define UART1_MCR_RTS_CTRL        ((uint8_t)(1<<1))        /*!< Source for modem output pin RTS */
+// #define UART1_MCR_LOOPB_EN        ((uint8_t)(1<<4))        /*!< Loop back mode select */
+// #define UART1_MCR_AUTO_RTS_EN    ((uint8_t)(1<<6))        /*!< Enable Auto RTS flow-control */
+// #define UART1_MCR_AUTO_CTS_EN    ((uint8_t)(1<<7))        /*!< Enable Auto CTS flow-control */
+// #define UART1_MCR_BITMASK        ((uint8_t)(0x0F3))        /*!< UART1 bit mask value */
+//
+// /*********************************************************************//**
+//  * Macro defines for Macro defines for UART line status register
+//  **********************************************************************/
+// #define UART_LSR_RDR        ((uint8_t)(1<<0))     /*!<Line status register: Receive data ready*/
+// #define UART_LSR_OE            ((uint8_t)(1<<1))     /*!<Line status register: Overrun error*/
+// #define UART_LSR_PE            ((uint8_t)(1<<2))     /*!<Line status register: Parity error*/
+// #define UART_LSR_FE            ((uint8_t)(1<<3))     /*!<Line status register: Framing error*/
+// #define UART_LSR_BI            ((uint8_t)(1<<4))     /*!<Line status register: Break interrupt*/
+// #define UART_LSR_THRE        ((uint8_t)(1<<5))     /*!<Line status register: Transmit holding register empty*/
+// #define UART_LSR_TEMT        ((uint8_t)(1<<6))     /*!<Line status register: Transmitter empty*/
+// #define UART_LSR_RXFE        ((uint8_t)(1<<7))     /*!<Error in RX FIFO*/
+// #define UART_LSR_BITMASK    ((uint8_t)(0xFF))     /*!<UART Line status bit mask */
+//
+// /*********************************************************************//**
+//  * Macro defines for Macro defines for UART Modem (UART1 only) status register
+//  **********************************************************************/
+// #define UART1_MSR_DELTA_CTS        ((uint8_t)(1<<0))    /*!< Set upon state change of input CTS */
+// #define UART1_MSR_DELTA_DSR        ((uint8_t)(1<<1))    /*!< Set upon state change of input DSR */
+// #define UART1_MSR_LO2HI_RI        ((uint8_t)(1<<2))    /*!< Set upon low to high transition of input RI */
+// #define UART1_MSR_DELTA_DCD        ((uint8_t)(1<<3))    /*!< Set upon state change of input DCD */
+// #define UART1_MSR_CTS            ((uint8_t)(1<<4))    /*!< Clear To Send State */
+// #define UART1_MSR_DSR            ((uint8_t)(1<<5))    /*!< Data Set Ready State */
+// #define UART1_MSR_RI            ((uint8_t)(1<<6))    /*!< Ring Indicator State */
+// #define UART1_MSR_DCD            ((uint8_t)(1<<7))    /*!< Data Carrier Detect State */
+// #define UART1_MSR_BITMASK        ((uint8_t)(0xFF))    /*!< MSR register bit-mask value */
+//
+// /*********************************************************************//**
+//  * Macro defines for Macro defines for UART Scratch Pad Register
+//  **********************************************************************/
+// #define UART_SCR_BIMASK        ((uint8_t)(0xFF))    /*!< UART Scratch Pad bit mask */
+//
+// /*********************************************************************//**
+//  * Macro defines for Macro defines for UART Auto baudrate control register
+//  **********************************************************************/
+// #define UART_ACR_START                ((uint32_t)(1<<0))    /**< UART Auto-baud start */
+// #define UART_ACR_MODE                ((uint32_t)(1<<1))    /**< UART Auto baudrate Mode 1 */
+// #define UART_ACR_AUTO_RESTART        ((uint32_t)(1<<2))    /**< UART Auto baudrate restart */
+// #define UART_ACR_ABEOINT_CLR        ((uint32_t)(1<<8))    /**< UART End of auto-baud interrupt clear */
+// #define UART_ACR_ABTOINT_CLR        ((uint32_t)(1<<9))    /**< UART Auto-baud time-out interrupt clear */
+// #define UART_ACR_BITMASK            ((uint32_t)(0x307))    /**< UART Auto Baudrate register bit mask */
+//
+// /*********************************************************************//**
+//  * Macro defines for Macro defines for UART IrDA control register
+//  **********************************************************************/
+// #define UART_ICR_IRDAEN            ((uint32_t)(1<<0))            /**< IrDA mode enable */
+// #define UART_ICR_IRDAINV        ((uint32_t)(1<<1))            /**< IrDA serial input inverted */
+// #define UART_ICR_FIXPULSE_EN    ((uint32_t)(1<<2))            /**< IrDA fixed pulse width mode */
+// #define UART_ICR_PULSEDIV(n)    ((uint32_t)((n&0x07)<<3))    /**< PulseDiv - Configures the pulse when FixPulseEn = 1 */
+// #define UART_ICR_BITMASK        ((uint32_t)(0x3F))            /*!< UART IRDA bit mask */
+//
+// /*********************************************************************//**
+//  * Macro defines for Macro defines for UART Fractional divider register
+//  **********************************************************************/
+// #define UART_FDR_DIVADDVAL(n)    ((uint32_t)(n&0x0F))        /**< Baud-rate generation pre-scaler divisor */
+// #define UART_FDR_MULVAL(n)        ((uint32_t)((n<<4)&0xF0))    /**< Baud-rate pre-scaler multiplier value */
+// #define UART_FDR_BITMASK        ((uint32_t)(0xFF))            /**< UART Fractional Divider register bit mask */
+//
+// /*********************************************************************//**
+//  * Macro defines for Macro defines for UART Tx Enable register
+//  **********************************************************************/
+// #define UART_TER_TXEN            ((uint8_t)(1<<7))         /*!< Transmit enable bit */
+// #define UART_TER_BITMASK        ((uint8_t)(0x80))        /**< UART Transmit Enable Register bit mask */
+//
+// /*********************************************************************//**
+//  * Macro defines for Macro defines for UART1 RS485 Control register
+//  **********************************************************************/
+// #define UART1_RS485CTRL_NMM_EN        ((uint32_t)(1<<0))    /*!< RS-485/EIA-485 Normal Multi-drop Mode (NMM)
+//                                                         is disabled */
+// #define UART1_RS485CTRL_RX_DIS        ((uint32_t)(1<<1))    /*!< The receiver is disabled */
+// #define UART1_RS485CTRL_AADEN        ((uint32_t)(1<<2))    /*!< Auto Address Detect (AAD) is enabled */
+// #define UART1_RS485CTRL_SEL_DTR        ((uint32_t)(1<<3))    /*!< If direction control is enabled
+//                                                         (bit DCTRL = 1), pin DTR is used for direction control */
+// #define UART1_RS485CTRL_DCTRL_EN    ((uint32_t)(1<<4))    /*!< Enable Auto Direction Control */
+// #define UART1_RS485CTRL_OINV_1        ((uint32_t)(1<<5))    /*!< This bit reverses the polarity of the direction
+//                                                         control signal on the RTS (or DTR) pin. The direction control pin
+//                                                         will be driven to logic "1" when the transmitter has data to be sent */
+// #define UART1_RS485CTRL_BITMASK        ((uint32_t)(0x3F))    /**< RS485 control bit-mask value */
+//
+// /*********************************************************************//**
+//  * Macro defines for Macro defines for UART1 RS-485 Address Match register
+//  **********************************************************************/
+// #define UART1_RS485ADRMATCH_BITMASK ((uint8_t)(0xFF))     /**< Bit mask value */
+//
+// /*********************************************************************//**
+//  * Macro defines for Macro defines for UART1 RS-485 Delay value register
+//  **********************************************************************/
+// /* Macro defines for UART1 RS-485 Delay value register */
+// #define UART1_RS485DLY_BITMASK        ((uint8_t)(0xFF))     /** Bit mask value */
+//
+// /*********************************************************************//**
+//  * Macro defines for Macro defines for UART FIFO Level register
+//  **********************************************************************/
+// #define UART_FIFOLVL_RXFIFOLVL(n)    ((uint32_t)(n&0x0F))        /**< Reflects the current level of the UART receiver FIFO */
+// #define UART_FIFOLVL_TXFIFOLVL(n)    ((uint32_t)((n>>8)&0x0F))    /**< Reflects the current level of the UART transmitter FIFO */
+// #define UART_FIFOLVL_BITMASK        ((uint32_t)(0x0F0F))        /**< UART FIFO Level Register bit mask */
+//
+//
+// /* ---------------- CHECK PARAMETER DEFINITIONS ---------------------------- */
+//
+// /** Macro to check the input UART_DATABIT parameters */
+// #define PARAM_UART_DATABIT(databit)    ((databit==UART_DATABIT_5) || (databit==UART_DATABIT_6)\
+// || (databit==UART_DATABIT_7) || (databit==UART_DATABIT_8))
+//
+// /** Macro to check the input UART_STOPBIT parameters */
+// #define PARAM_UART_STOPBIT(stopbit)    ((stopbit==UART_STOPBIT_1) || (stopbit==UART_STOPBIT_2))
+//
+// /** Macro to check the input UART_PARITY parameters */
+// #define PARAM_UART_PARITY(parity)    ((parity==UART_PARITY_NONE) || (parity==UART_PARITY_ODD) \
+// || (parity==UART_PARITY_EVEN) || (parity==UART_PARITY_SP_1) \
+// || (parity==UART_PARITY_SP_0))
+//
+// /** Macro to check the input UART_FIFO parameters */
+// #define PARAM_UART_FIFO_LEVEL(fifo)    ((fifo==UART_FIFO_TRGLEV0) \
+// || (fifo==UART_FIFO_TRGLEV1) || (fifo==UART_FIFO_TRGLEV2) \
+// || (fifo==UART_FIFO_TRGLEV3))
+//
+// /** Macro to check the input UART_INTCFG parameters */
+// #define PARAM_UART_INTCFG(IntCfg)    ((IntCfg==UART_INTCFG_RBR) || (IntCfg==UART_INTCFG_THRE) \
+// || (IntCfg==UART_INTCFG_RLS) || (IntCfg==UART_INTCFG_ABEO) \
+// || (IntCfg==UART_INTCFG_ABTO))
+//
+// /** Macro to check the input UART1_INTCFG parameters - expansion input parameter for UART1 */
+// #define PARAM_UART1_INTCFG(IntCfg)    ((IntCfg==UART1_INTCFG_MS) || (IntCfg==UART1_INTCFG_CTS))
+//
+// /** Macro to check the input UART_AUTOBAUD_MODE parameters */
+// #define PARAM_UART_AUTOBAUD_MODE(ABmode)    ((ABmode==UART_AUTOBAUD_MODE0) || (ABmode==UART_AUTOBAUD_MODE1))
+//
+// /** Macro to check the input UART_AUTOBAUD_INTSTAT parameters */
+// #define PARAM_UART_AUTOBAUD_INTSTAT(ABIntStat)    ((ABIntStat==UART_AUTOBAUD_INTSTAT_ABEO) || \
+//         (ABIntStat==UART_AUTOBAUD_INTSTAT_ABTO))
+//
+// /** Macro to check the input UART_IrDA_PULSEDIV parameters */
+// #define PARAM_UART_IrDA_PULSEDIV(PulseDiv)    ((PulseDiv==UART_IrDA_PULSEDIV2) || (PulseDiv==UART_IrDA_PULSEDIV4) \
+// || (PulseDiv==UART_IrDA_PULSEDIV8) || (PulseDiv==UART_IrDA_PULSEDIV16) \
+// || (PulseDiv==UART_IrDA_PULSEDIV32) || (PulseDiv==UART_IrDA_PULSEDIV64) \
+// || (PulseDiv==UART_IrDA_PULSEDIV128) || (PulseDiv==UART_IrDA_PULSEDIV256))
+//
+// /* Macro to check the input UART1_SignalState parameters */
+// #define PARAM_UART1_SIGNALSTATE(x) ((x==INACTIVE) || (x==ACTIVE))
+//
+// /** Macro to check the input PARAM_UART1_MODEM_PIN parameters */
+// #define PARAM_UART1_MODEM_PIN(x) ((x==UART1_MODEM_PIN_DTR) || (x==UART1_MODEM_PIN_RTS))
+//
+// /** Macro to check the input PARAM_UART1_MODEM_MODE parameters */
+// #define PARAM_UART1_MODEM_MODE(x) ((x==UART1_MODEM_MODE_LOOPBACK) || (x==UART1_MODEM_MODE_AUTO_RTS) \
+// || (x==UART1_MODEM_MODE_AUTO_CTS))
+//
+// /** Macro to check the direction control pin type */
+// #define PARAM_UART_RS485_DIRCTRL_PIN(x)    ((x==UART1_RS485_DIRCTRL_RTS) || (x==UART1_RS485_DIRCTRL_DTR))
+//
+// /* Macro to determine if it is valid UART port number */
+// #define PARAM_UARTx(x)    ((((uint32_t *)x)==((uint32_t *)LPC_UART0)) \
+// || (((uint32_t *)x)==((uint32_t *)LPC_UART1)) \
+// || (((uint32_t *)x)==((uint32_t *)LPC_UART2)) \
+// || (((uint32_t *)x)==((uint32_t *)LPC_UART3)))
+// #define PARAM_UART_IrDA(x) (((uint32_t *)x)==((uint32_t *)LPC_UART3))
+// #define PARAM_UART1_MODEM(x) (((uint32_t *)x)==((uint32_t *)LPC_UART1))
+//
+// /** Macro to check the input value for UART1_RS485_CFG_MATCHADDRVALUE parameter */
+// #define PARAM_UART1_RS485_CFG_MATCHADDRVALUE(x) ((x<0xFF))
+//
+// /** Macro to check the input value for UART1_RS485_CFG_DELAYVALUE parameter */
+// #define PARAM_UART1_RS485_CFG_DELAYVALUE(x) ((x<0xFF))
+//
+// /**
+//  * @}
+//  */
+//
+//
+// /* Public Types --------------------------------------------------------------- */
+// /** @defgroup UART_Public_Types UART Public Types
+//  * @{
+//  */
+//
+// /**
+//  * @brief UART Databit type definitions
+//  */
+// typedef enum {
+//     UART_DATABIT_5        = 0,             /*!< UART 5 bit data mode */
+//     UART_DATABIT_6,                         /*!< UART 6 bit data mode */
+//     UART_DATABIT_7,                         /*!< UART 7 bit data mode */
+//     UART_DATABIT_8                         /*!< UART 8 bit data mode */
+// } UART_DATABIT_Type;
+//
+// /**
+//  * @brief UART Stop bit type definitions
+//  */
+// typedef enum {
+//     UART_STOPBIT_1        = (0),                       /*!< UART 1 Stop Bits Select */
+//     UART_STOPBIT_2,                                     /*!< UART Two Stop Bits Select */
+// } UART_STOPBIT_Type;
+//
+// /**
+//  * @brief UART Parity type definitions
+//  */
+// typedef enum {
+//     UART_PARITY_NONE     = 0,                    /*!< No parity */
+//     UART_PARITY_ODD,                             /*!< Odd parity */
+//     UART_PARITY_EVEN,                             /*!< Even parity */
+//     UART_PARITY_SP_1,                             /*!< Forced "1" stick parity */
+//     UART_PARITY_SP_0                             /*!< Forced "0" stick parity */
+// } UART_PARITY_Type;
+//
+// /**
+//  * @brief FIFO Level type definitions
+//  */
+// typedef enum {
+//     UART_FIFO_TRGLEV0 = 0,    /*!< UART FIFO trigger level 0: 1 character */
+//     UART_FIFO_TRGLEV1,         /*!< UART FIFO trigger level 1: 4 character */
+//     UART_FIFO_TRGLEV2,        /*!< UART FIFO trigger level 2: 8 character */
+//     UART_FIFO_TRGLEV3        /*!< UART FIFO trigger level 3: 14 character */
+// } UART_FITO_LEVEL_Type;
+//
+// /********************************************************************//**
+// * @brief UART Interrupt Type definitions
+// **********************************************************************/
+// typedef enum {
+//     UART_INTCFG_RBR = 0,    /*!< RBR Interrupt enable*/
+//     UART_INTCFG_THRE,        /*!< THR Interrupt enable*/
+//     UART_INTCFG_RLS,        /*!< RX line status interrupt enable*/
+//     UART1_INTCFG_MS,        /*!< Modem status interrupt enable (UART1 only) */
+//     UART1_INTCFG_CTS,        /*!< CTS1 signal transition interrupt enable (UART1 only) */
+//     UART_INTCFG_ABEO,        /*!< Enables the end of auto-baud interrupt */
+//     UART_INTCFG_ABTO        /*!< Enables the auto-baud time-out interrupt */
+// } UART_INT_Type;
+//
+// /**
+//  * @brief UART Line Status Type definition
+//  */
+// typedef enum {
+//     UART_LINESTAT_RDR    = UART_LSR_RDR,            /*!<Line status register: Receive data ready*/
+//     UART_LINESTAT_OE    = UART_LSR_OE,            /*!<Line status register: Overrun error*/
+//     UART_LINESTAT_PE    = UART_LSR_PE,            /*!<Line status register: Parity error*/
+//     UART_LINESTAT_FE    = UART_LSR_FE,            /*!<Line status register: Framing error*/
+//     UART_LINESTAT_BI    = UART_LSR_BI,            /*!<Line status register: Break interrupt*/
+//     UART_LINESTAT_THRE    = UART_LSR_THRE,        /*!<Line status register: Transmit holding register empty*/
+//     UART_LINESTAT_TEMT    = UART_LSR_TEMT,        /*!<Line status register: Transmitter empty*/
+//     UART_LINESTAT_RXFE    = UART_LSR_RXFE            /*!<Error in RX FIFO*/
+// } UART_LS_Type;
+//
+// /**
+//  * @brief UART Auto-baudrate mode type definition
+//  */
+// typedef enum {
+//     UART_AUTOBAUD_MODE0                = 0,            /**< UART Auto baudrate Mode 0 */
+//     UART_AUTOBAUD_MODE1,                            /**< UART Auto baudrate Mode 1 */
+// } UART_AB_MODE_Type;
+//
+// /**
+//  * @brief Auto Baudrate mode configuration type definition
+//  */
+// typedef struct {
+//     UART_AB_MODE_Type    ABMode;            /**< Autobaudrate mode */
+//     FunctionalState        AutoRestart;    /**< Auto Restart state */
+// } UART_AB_CFG_Type;
+//
+// /**
+//  * @brief UART End of Auto-baudrate type definition
+//  */
+// typedef enum {
+//     UART_AUTOBAUD_INTSTAT_ABEO        = UART_IIR_ABEO_INT,        /**< UART End of auto-baud interrupt  */
+//     UART_AUTOBAUD_INTSTAT_ABTO        = UART_IIR_ABTO_INT            /**< UART Auto-baud time-out interrupt  */
+// }UART_ABEO_Type;
+//
+// /**
+//  * UART IrDA Control type Definition
+//  */
+// typedef enum {
+//     UART_IrDA_PULSEDIV2        = 0,        /**< Pulse width = 2 * Tpclk
+//                                         - Configures the pulse when FixPulseEn = 1 */
+//     UART_IrDA_PULSEDIV4,                /**< Pulse width = 4 * Tpclk
+//                                         - Configures the pulse when FixPulseEn = 1 */
+//     UART_IrDA_PULSEDIV8,                /**< Pulse width = 8 * Tpclk
+//                                         - Configures the pulse when FixPulseEn = 1 */
+//     UART_IrDA_PULSEDIV16,                /**< Pulse width = 16 * Tpclk
+//                                         - Configures the pulse when FixPulseEn = 1 */
+//     UART_IrDA_PULSEDIV32,                /**< Pulse width = 32 * Tpclk
+//                                         - Configures the pulse when FixPulseEn = 1 */
+//     UART_IrDA_PULSEDIV64,                /**< Pulse width = 64 * Tpclk
+//                                         - Configures the pulse when FixPulseEn = 1 */
+//     UART_IrDA_PULSEDIV128,                /**< Pulse width = 128 * Tpclk
+//                                         - Configures the pulse when FixPulseEn = 1 */
+//     UART_IrDA_PULSEDIV256                /**< Pulse width = 256 * Tpclk
+//                                         - Configures the pulse when FixPulseEn = 1 */
+// } UART_IrDA_PULSE_Type;
+//
+// /********************************************************************//**
+// * @brief UART1 Full modem -  Signal states definition
+// **********************************************************************/
+// typedef enum {
+//     INACTIVE = 0,            /* In-active state */
+//     ACTIVE = !INACTIVE         /* Active state */
+// }UART1_SignalState;
+//
+// /**
+//  * @brief UART modem status type definition
+//  */
+// typedef enum {
+//     UART1_MODEM_STAT_DELTA_CTS    = UART1_MSR_DELTA_CTS,        /*!< Set upon state change of input CTS */
+//     UART1_MODEM_STAT_DELTA_DSR    = UART1_MSR_DELTA_DSR,        /*!< Set upon state change of input DSR */
+//     UART1_MODEM_STAT_LO2HI_RI    = UART1_MSR_LO2HI_RI,        /*!< Set upon low to high transition of input RI */
+//     UART1_MODEM_STAT_DELTA_DCD    = UART1_MSR_DELTA_DCD,        /*!< Set upon state change of input DCD */
+//     UART1_MODEM_STAT_CTS        = UART1_MSR_CTS,            /*!< Clear To Send State */
+//     UART1_MODEM_STAT_DSR        = UART1_MSR_DSR,            /*!< Data Set Ready State */
+//     UART1_MODEM_STAT_RI            = UART1_MSR_RI,                /*!< Ring Indicator State */
+//     UART1_MODEM_STAT_DCD        = UART1_MSR_DCD                /*!< Data Carrier Detect State */
+// } UART_MODEM_STAT_type;
+//
+// /**
+//  * @brief Modem output pin type definition
+//  */
+// typedef enum {
+//     UART1_MODEM_PIN_DTR            = 0,        /*!< Source for modem output pin DTR */
+//     UART1_MODEM_PIN_RTS                        /*!< Source for modem output pin RTS */
+// } UART_MODEM_PIN_Type;
+//
+// /**
+//  * @brief UART Modem mode type definition
+//  */
+// typedef enum {
+//     UART1_MODEM_MODE_LOOPBACK    = 0,        /*!< Loop back mode select */
+//     UART1_MODEM_MODE_AUTO_RTS,                /*!< Enable Auto RTS flow-control */
+//     UART1_MODEM_MODE_AUTO_CTS                 /*!< Enable Auto CTS flow-control */
+// } UART_MODEM_MODE_Type;
+//
+// /**
+//  * @brief UART Direction Control Pin type definition
+//  */
+// typedef enum {
+//     UART1_RS485_DIRCTRL_RTS = 0,    /**< Pin RTS is used for direction control */
+//     UART1_RS485_DIRCTRL_DTR            /**< Pin DTR is used for direction control */
+// } UART_RS485_DIRCTRL_PIN_Type;
+//
+// /********************************************************************//**
+// * @brief UART Configuration Structure definition
+// **********************************************************************/
+// typedef struct {
+//   uint32_t Baud_rate;           /**< UART baud rate */
+//   UART_PARITY_Type Parity;        /**< Parity selection, should be:
+//                                - UART_PARITY_NONE: No parity
+//                                - UART_PARITY_ODD: Odd parity
+//                                - UART_PARITY_EVEN: Even parity
+//                                - UART_PARITY_SP_1: Forced "1" stick parity
+//                                - UART_PARITY_SP_0: Forced "0" stick parity
+//                                */
+//   UART_DATABIT_Type Databits;   /**< Number of data bits, should be:
+//                                - UART_DATABIT_5: UART 5 bit data mode
+//                                - UART_DATABIT_6: UART 6 bit data mode
+//                                - UART_DATABIT_7: UART 7 bit data mode
+//                                - UART_DATABIT_8: UART 8 bit data mode
+//                                */
+//   UART_STOPBIT_Type Stopbits;   /**< Number of stop bits, should be:
+//                                - UART_STOPBIT_1: UART 1 Stop Bits Select
+//                                - UART_STOPBIT_2: UART 2 Stop Bits Select
+//                                */
+// } UART_CFG_Type;
+//
+// /********************************************************************//**
+// * @brief UART FIFO Configuration Structure definition
+// **********************************************************************/
+//
+// typedef struct {
+//     FunctionalState FIFO_ResetRxBuf;    /**< Reset Rx FIFO command state , should be:
+//                                          - ENABLE: Reset Rx FIFO in UART
+//                                          - DISABLE: Do not reset Rx FIFO  in UART
+//                                          */
+//     FunctionalState FIFO_ResetTxBuf;    /**< Reset Tx FIFO command state , should be:
+//                                          - ENABLE: Reset Tx FIFO in UART
+//                                          - DISABLE: Do not reset Tx FIFO  in UART
+//                                          */
+//     FunctionalState FIFO_DMAMode;        /**< DMA mode, should be:
+//                                          - ENABLE: Enable DMA mode in UART
+//                                          - DISABLE: Disable DMA mode in UART
+//                                          */
+//     UART_FITO_LEVEL_Type FIFO_Level;    /**< Rx FIFO trigger level, should be:
+//                                         - UART_FIFO_TRGLEV0: UART FIFO trigger level 0: 1 character
+//                                         - UART_FIFO_TRGLEV1: UART FIFO trigger level 1: 4 character
+//                                         - UART_FIFO_TRGLEV2: UART FIFO trigger level 2: 8 character
+//                                         - UART_FIFO_TRGLEV3: UART FIFO trigger level 3: 14 character
+//                                         */
+// } UART_FIFO_CFG_Type;
+//
+// /********************************************************************//**
+// * @brief UART1 Full modem -  RS485 Control configuration type
+// **********************************************************************/
+// typedef struct {
+//     FunctionalState NormalMultiDropMode_State; /*!< Normal MultiDrop mode State:
+//                                                     - ENABLE: Enable this function.
+//                                                     - DISABLE: Disable this function. */
+//     FunctionalState Rx_State;                    /*!< Receiver State:
+//                                                     - ENABLE: Enable Receiver.
+//                                                     - DISABLE: Disable Receiver. */
+//     FunctionalState AutoAddrDetect_State;        /*!< Auto Address Detect mode state:
+//                                                 - ENABLE: ENABLE this function.
+//                                                 - DISABLE: Disable this function. */
+//     FunctionalState AutoDirCtrl_State;            /*!< Auto Direction Control State:
+//                                                 - ENABLE: Enable this function.
+//                                                 - DISABLE: Disable this function. */
+//     UART_RS485_DIRCTRL_PIN_Type DirCtrlPin;        /*!< If direction control is enabled, state:
+//                                                 - UART1_RS485_DIRCTRL_RTS:
+//                                                 pin RTS is used for direction control.
+//                                                 - UART1_RS485_DIRCTRL_DTR:
+//                                                 pin DTR is used for direction control. */
+//      SetState DirCtrlPol_Level;                    /*!< Polarity of the direction control signal on
+//                                                 the RTS (or DTR) pin:
+//                                                 - RESET: The direction control pin will be driven
+//                                                 to logic "0" when the transmitter has data to be sent.
+//                                                 - SET: The direction control pin will be driven
+//                                                 to logic "1" when the transmitter has data to be sent. */
+//     uint8_t MatchAddrValue;                    /*!< address match value for RS-485/EIA-485 mode, 8-bit long */
+//     uint8_t DelayValue;                        /*!< delay time is in periods of the baud clock, 8-bit long */
+// } UART1_RS485_CTRLCFG_Type;
+//
+// /**
+//  * @}
+//  */
+//
+//
+//      DO NOT USE
+//      DO NOT USE
+//      DO NOT USE
+//      DO NOT USE
+//      DO NOT USE
+//      DO NOT USE
+//      DO NOT USE
+//      DO NOT USE
+//      DO NOT USE
+//      DO NOT USE
+//      DO NOT USE
+//      DO NOT USE
+// /* Public Functions ----------------------------------------------------------- */
+// /** @defgroup UART_Public_Functions UART Public Functions
+//  * @{
+//  */
+// /* UART Init/DeInit functions --------------------------------------------------*/
+// void UART_Init(LPC_UART_TypeDef *UARTx, UART_CFG_Type *UART_ConfigStruct);
+// void UART_DeInit(LPC_UART_TypeDef* UARTx);
+// void UART_ConfigStructInit(UART_CFG_Type *UART_InitStruct);
+//
+// /* UART Send/Receive functions -------------------------------------------------*/
+// void UART_SendByte(LPC_UART_TypeDef* UARTx, uint8_t Data);
+// uint8_t UART_ReceiveByte(LPC_UART_TypeDef* UARTx);
+// uint32_t UART_Send(LPC_UART_TypeDef *UARTx, uint8_t *txbuf,
+//         uint32_t buflen, TRANSFER_BLOCK_Type flag);
+// uint32_t UART_Receive(LPC_UART_TypeDef *UARTx, uint8_t *rxbuf, \
+//         uint32_t buflen, TRANSFER_BLOCK_Type flag);
+//
+//      DO NOT USE
+//      DO NOT USE
+//      DO NOT USE
+//      DO NOT USE
+//      DO NOT USE
+//      DO NOT USE
+//      DO NOT USE
+//      DO NOT USE
+//      DO NOT USE
+//      DO NOT USE
+//      DO NOT USE
+//      DO NOT USE
+// /* UART FIFO functions ----------------------------------------------------------*/
+// void UART_FIFOConfig(LPC_UART_TypeDef *UARTx, UART_FIFO_CFG_Type *FIFOCfg);
+// void UART_FIFOConfigStructInit(UART_FIFO_CFG_Type *UART_FIFOInitStruct);
+//
+// /* UART get information functions -----------------------------------------------*/
+// uint32_t UART_GetIntId(LPC_UART_TypeDef* UARTx);
+// uint8_t UART_GetLineStatus(LPC_UART_TypeDef* UARTx);
+//
+// /* UART operate functions -------------------------------------------------------*/
+// void UART_IntConfig(LPC_UART_TypeDef *UARTx, UART_INT_Type UARTIntCfg, \
+//                 FunctionalState NewState);
+// void UART_TxCmd(LPC_UART_TypeDef *UARTx, FunctionalState NewState);
+// FlagStatus UART_CheckBusy(LPC_UART_TypeDef *UARTx);
+// void UART_ForceBreak(LPC_UART_TypeDef* UARTx);
+//
+//      DO NOT USE
+//      DO NOT USE
+//      DO NOT USE
+//      DO NOT USE
+//      DO NOT USE
+//      DO NOT USE
+//      DO NOT USE
+//      DO NOT USE
+//      DO NOT USE
+//      DO NOT USE
+//      DO NOT USE
+//      DO NOT USE
+// /* UART Auto-baud functions -----------------------------------------------------*/
+// void UART_ABClearIntPending(LPC_UART_TypeDef *UARTx, UART_ABEO_Type ABIntType);
+// void UART_ABCmd(LPC_UART_TypeDef *UARTx, UART_AB_CFG_Type *ABConfigStruct, \
+//                 FunctionalState NewState);
+//
+// /* UART1 FullModem functions ----------------------------------------------------*/
+// void UART_FullModemForcePinState(LPC_UART1_TypeDef *UARTx, UART_MODEM_PIN_Type Pin, \
+//                             UART1_SignalState NewState);
+// void UART_FullModemConfigMode(LPC_UART1_TypeDef *UARTx, UART_MODEM_MODE_Type Mode, \
+//                             FunctionalState NewState);
+// uint8_t UART_FullModemGetStatus(LPC_UART1_TypeDef *UARTx);
+//
+// /* UART RS485 functions ----------------------------------------------------------*/
+// void UART_RS485Config(LPC_UART1_TypeDef *UARTx, \
+//         UART1_RS485_CTRLCFG_Type *RS485ConfigStruct);
+// void UART_RS485ReceiverCmd(LPC_UART1_TypeDef *UARTx, FunctionalState NewState);
+// void UART_RS485SendSlvAddr(LPC_UART1_TypeDef *UARTx, uint8_t SlvAddr);
+// uint32_t UART_RS485SendData(LPC_UART1_TypeDef *UARTx, uint8_t *pData, uint32_t size);
+//
+//      DO NOT USE
+//      DO NOT USE
+//      DO NOT USE
+//      DO NOT USE
+//      DO NOT USE
+//      DO NOT USE
+//      DO NOT USE
+//      DO NOT USE
+//      DO NOT USE
+//      DO NOT USE
+//      DO NOT USE
+//      DO NOT USE
+// /* UART IrDA functions-------------------------------------------------------------*/
+// void UART_IrDAInvtInputCmd(LPC_UART_TypeDef* UARTx, FunctionalState NewState);
+// void UART_IrDACmd(LPC_UART_TypeDef* UARTx, FunctionalState NewState);
+// void UART_IrDAPulseDivConfig(LPC_UART_TypeDef *UARTx, UART_IrDA_PULSE_Type PulseDiv);
+// /**
+//  * @}
+//  */
+//
+//
+// #ifdef __cplusplus
+// }
+// #endif
+//
+//
 #endif /* __LPC17XX_UART_H */
-
-/**
- * @}
- */
-
+//
+// /**
+//  * @}
+//  */
+//
 /* --------------------------------- End Of File ------------------------------ */

--- a/CMSISv2p00_LPC17xx/Drivers/inc/lpc17xx_uartx.h
+++ b/CMSISv2p00_LPC17xx/Drivers/inc/lpc17xx_uartx.h
@@ -1,0 +1,582 @@
+/**
+ * @file        lpc17xx_uartx.h
+ * @brief       Contains all macro definitions and function prototypes
+ *              support for UART firmware library on LPC17xx
+ * @version     1.0
+ * @date        02. November. 2025
+ * @author      David Trujillo Medina
+ *
+ * Software that is described herein is for illustrative purposes only
+ * which provides customers with programming information regarding the
+ * products. This software is supplied "AS IS" without any warranties.
+ * NXP Semiconductors assumes no responsibility or liability for the
+ * use of the software, conveys no license or title under any patent,
+ * copyright, or mask work right to the product. NXP Semiconductors
+ * reserves the right to make changes in the software without
+ * notification. NXP Semiconductors also make no representation or
+ * warranty that such application will be suitable for the specified
+ * use without further testing or modification.
+ */
+
+/* ---------------------------- Peripheral group ---------------------------- */
+/** @defgroup UARTX UARTX
+ * @ingroup LPC1700CMSIS_FwLib_Drivers
+ * @{
+ */
+
+#ifndef LPC17XX_UARTX_H
+#define LPC17XX_UARTX_H
+
+/* -------------------------------- Includes -------------------------------- */
+#include "LPC17xx.h"
+#include "lpc_types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* ----------------------------- Private Macros ----------------------------- */
+/** @defgroup UARTX_Private_Macros UART Private Macros
+ * @{
+ */
+
+/** UARTX time-out definitions for functions with Blocking Flag mode. */
+#define UARTX_BLOCKING_TIMEOUT (0xFFFFFFFFUL)
+
+/** Accepted Error baud rate value (in percent unit). */
+#define UARTX_ACCEPTED_BAUDRATE_ERROR (3)
+
+/** Macro for loading least significant halfs of divisors. */
+#define UARTX_LOAD_DLL(div) ((div) & 0xFF)
+/** Macro for loading most significant halfs of divisors. */
+#define UARTX_LOAD_DLM(div) (((div) >> 8) & 0xFF)
+
+/** Baud-rate generation pre-scaler divisor. */
+#define UARTX_FDR_DIVADDVAL(n) ((uint32_t)(n & 0x0F))
+/** Baud-rate pre-scaler multiplier value. */
+#define UARTX_FDR_MULVAL(n)    ((uint32_t)((n << 4) & 0xF0))
+/** UART Fractional Divider register bit mask. */
+#define UARTX_FDR_BITMASK      ((uint32_t)(0xFF))
+
+/* ---------------------------- BIT DEFINITIONS ----------------------------- */
+/** UARTX Received Buffer mask bit (8 bits). */
+#define UARTX_RBR_MASKBIT ((uint8_t)0xFF)
+/** UARTX Transmit Holding mask bit (8 bits). */
+#define UARTX_THR_MASKBIT ((uint8_t)0xFF)
+
+/** UARTX FIFO enable. */
+#define UARTX_FCR_FIFO_EN     ((1 << 0))
+/** UARTX FIFO RX reset. */
+#define UARTX_FCR_RX_RS       ((1 << 1))
+/** UARTX FIFO TX reset. */
+#define UARTX_FCR_TX_RS       ((1 << 2))
+/** UARTX DMA mode selection. */
+#define UARTX_FCR_DMAMODE_SEL ((1 << 3))
+/** UARTX FIFO control bit mask */
+#define UARTX_FCR_BITMASK     ((0xCF))
+/** UARTX FIFO size. */
+#define UARTX_TX_FIFO_SIZE    (16)
+
+/** Line status register: Receive data ready. */
+#define UARTX_LSR_RDR     ((1 << 0))
+/** Line status register: Transmit holding register empty. */
+#define UARTX_LSR_THRE    ((1 << 5))
+/** Line status register: Transmitter empty. */
+#define UARTX_LSR_TEMT    ((1 << 6))
+/** UARTX Line status bit mask. */
+#define UARTX_LSR_BITMASK ((0xFF))
+
+/** Transmit enable bit. */
+#define UARTX_TER_TXEN    ((1 << 7))
+/** UARTX Transmit Enable Register bit mask. */
+#define UARTX_TER_BITMASK ((0x80))
+
+/** UARTX Two Stop Bits Select. */
+#define UARTX_LCR_STOPBIT_1   ((0 << 2))
+/** UARTX Two Stop Bits Select. */
+#define UARTX_LCR_STOPBIT_2   ((1 << 2))
+/** UARTX Parity Enable. */
+#define UARTX_LCR_PARITY_EN   ((1 << 3))
+/** UARTX Odd Parity Select. */
+#define UARTX_LCR_PARITY_ODD  ((0 << 4))
+/** UARTX Even Parity Select. */
+#define UARTX_LCR_PARITY_EVEN ((1 << 4))
+/** UARTX force 1 stick parity. */
+#define UARTX_LCR_PARITY_F_1  ((2 << 4))
+/** UARTX force 0 stick parity. */
+#define UARTX_LCR_PARITY_F_0  ((3 << 4))
+/** UARTX Transmission Break enable. */
+#define UARTX_LCR_BREAK_EN    ((1 << 6))
+/** UARTX Divisor Latches Access bit enable. */
+#define UARTX_LCR_DLAB_EN     ((1 << 7))
+/** UART line control bit mask. */
+#define UARTX_LCR_BITMASK     ((0xFF))
+
+/** RBR Interrupt enable. */
+#define UARTX_IER_RBRINT_EN  ((1 << 0))
+/** THR Interrupt enable. */
+#define UARTX_IER_THREINT_EN ((1 << 1))
+/** RX line status interrupt enable. */
+#define UARTX_IER_RLSINT_EN  ((1 << 2))
+/** End of auto-baud interrupt enable. */
+#define UARTX_IER_ABEOINT_EN ((1 << 8))
+/** Auto-baud time-out interrupt enable. */
+#define UARTX_IER_ABTOINT_EN ((1 << 9))
+/** UARTX interrupt enable register bit mask */
+#define UARTX_IER_BITMASK    ((0x307))
+
+/** End of auto-baud interrupt. */
+#define UARTX_IIR_ABEO_INT ((1 << 8))
+/** Auto-baud time-out interrupt. */
+#define UARTX_IIR_ABTO_INT ((1 << 9))
+
+/** UARTX Auto-baud start. */
+#define UARTX_ACR_START        ((1 << 0))
+/** UARTX Auto baudrate Mode 1. */
+#define UARTX_ACR_MODE         ((1 << 1))
+/** UARTX Auto baudrate restart. */
+#define UARTX_ACR_AUTO_RESTART ((1 << 2))
+
+/** IrDA mode enable. */
+#define UARTX_ICR_IRDAEN      ((1 << 0))
+/** IrDA serial input inverted. */
+#define UARTX_ICR_IRDAINV     ((1 << 1))
+/** IrDA fixed pulse width mode. */
+#define UARTX_ICR_FIXPULSE_EN ((1 << 2))
+/** PulseDiv - Configures the pulse when FixPulseEn = 1 */
+#define UARTX_ICR_PULSEDIV(n) ((uint32_t)((n & 0x07) << 3))
+/** UARTX IRDA bit mask. */
+#define UARTX_ICR_BITMASK     ((0x3F))
+
+/* ---------------------- CHECK PARAMETER DEFINITIONS ----------------------- */
+/** Check UARTX parameter. */
+#define PARAM_UARTX(n)                                                                       \
+    (((uintptr_t)(n) == (uintptr_t)LPC_UART0) || ((uintptr_t)(n) == (uintptr_t)LPC_UART2) || \
+     ((uintptr_t)(n) == (uintptr_t)LPC_UART3))
+
+/**
+ * @}
+ */
+
+/* ------------------------------ Public Types ------------------------------ */
+/** @defgroup UARTX_Public_Types UARTX Public Types
+ * @{
+ */
+
+/**
+ * @brief UARTX Parity type definitions
+ */
+typedef enum {
+    UARTX_PARITY_NONE = 0, /*!< No parity. */
+    UARTX_PARITY_ODD,      /*!< Odd parity. */
+    UARTX_PARITY_EVEN,     /*!< Even parity. */
+    UARTX_PARITY_1,        /*!< Forced "1". */
+    UARTX_PARITY_0         /*!< Forced "0". */
+} UARTX_PARITY;
+/** Check UARTX Parity option parameter */
+#define PARAM_UARTX_PARITY(OPT) (((OPT) >= UARTX_PARITY_NONE && (OPT) <= UARTX_PARITY_0))
+
+/**
+ * @brief UARTX Databit type definitions
+ */
+typedef enum {
+    UARTX_DATABIT_5 = 0, /*!< 5 bit character length. */
+    UARTX_DATABIT_6,     /*!< 6 bit character length. */
+    UARTX_DATABIT_7,     /*!< 7 bit character length. */
+    UARTX_DATABIT_8      /*!< 8 bit character length. */
+} UARTX_CHAR_LENGTH;
+/** Check UARTX Databit option parameter */
+#define PARAM_UARTX_CHAR_LENGTH(OPT) (((OPT) >= UARTX_DATABIT_5 && (OPT) <= UARTX_DATABIT_8))
+
+/**
+ * @brief UARTX Stop bit type definitions
+ */
+typedef enum {
+    UARTX_STOPBITS_1 = 0, /* 1 stop bit. */
+    UARTX_STOPBITS_2,     /* 2 stop bits. */
+} UARTX_STOPBITS;
+/** Check UARTX Stop bit option parameter */
+#define PARAM_UARTX_STOPBITS(OPT) (((OPT) >= UARTX_STOPBITS_1 && (OPT) <= UARTX_STOPBITS_2))
+
+/**
+ * @brief FIFO Level type definitions
+ */
+typedef enum {
+    UARTX_FIFO_TRG_1 = 0, /*!< FIFO trigger level: 1 character. */
+    UARTX_FIFO_TRG_4,     /*!< FIFO trigger level: 4 character. */
+    UARTX_FIFO_TRG_8,     /*!< FIFO trigger level: 8 character. */
+    UARTX_FIFO_TRG_14     /*!< FIFO trigger level: 14 character. */
+} UARTX_FIFO_LEVEL;
+/** Check UARTX FIFO Level option parameter */
+#define PARAM_UARTX_FIFO_LEVEL(OPT) (((OPT) >= UARTX_FIFO_TRG_1 && (OPT) <= UARTX_FIFO_TRG_14))
+
+/**
+ * @brief UARTX Auto-baudrate mode type definition
+ */
+typedef enum {
+    UARTX_AUTOBAUD_MODE0 = 0, /**< UARTX Auto baudrate Mode 0. */
+    UARTX_AUTOBAUD_MODE1,     /**< UARTX Auto baudrate Mode 1. */
+} UARTX_AB_MODE;
+/** Check UARTX Auto-baudrate mode option parameter */
+#define PARAM_UARTX_AB_MODE(OPT) (((OPT) >= UARTX_AUTOBAUD_MODE0 && (OPT) <= UARTX_AUTOBAUD_MODE1))
+
+/**
+ * @brief UARTX Interrupt Type definitions
+ */
+typedef enum {
+    UARTX_INT_RBR = 0, /*!< RBR Interrupt enable. */
+    UARTX_INT_THRE,    /*!< THR Interrupt enable. */
+    UARTX_INT_RXLS,    /*!< RX line status interrupt enable. */
+    UARTX_INT_ABEO,    /*!< End of auto-baud interrupt enable. */
+    UARTX_INT_ABTO     /*!< Time-out of auto-baud interrupt enable. */
+} UARTX_INT;
+/** Check UARTX Interrupt option parameter */
+#define PARAM_UARTX_INT_CFG(OPT) (((OPT) >= UARTX_INT_RBR) && ((OPT) <= UARTX_INT_ABTO))
+/** Check UARTX Auto-baudrate interrupt option parameter */
+#define PARAM_UARTX_AB_INT(OPT)  (((OPT) == UARTX_INT_ABEO) || ((OPT) != UARTX_INT_ABTO))
+
+/**
+ * UART IrDA Control type Definition
+ */
+typedef enum {
+    UARTX_IrDA_PULSEDIV2 = 0, /**< Pulse width = 2 * Tpclk. */
+    UARTX_IrDA_PULSEDIV4,     /**< Pulse width = 4 * Tpclk. */
+    UARTX_IrDA_PULSEDIV8,     /**< Pulse width = 8 * Tpclk. */
+    UARTX_IrDA_PULSEDIV16,    /**< Pulse width = 16 * Tpclk. */
+    UARTX_IrDA_PULSEDIV32,    /**< Pulse width = 32 * Tpclk. */
+    UARTX_IrDA_PULSEDIV64,    /**< Pulse width = 64 * Tpclk. */
+    UARTX_IrDA_PULSEDIV128,   /**< Pulse width = 128 * Tpclk. */
+    UARTX_IrDA_PULSEDIV256    /**< Pulse width = 256 * Tpclk. */
+} UARTX_IrDA_PULSE_Type;
+/** Check UARTX IrDA Pulse Divider option parameter */
+#define PARAM_UARTX_IrDA_PULSE_DIV(OPT) (((OPT) >= UARTX_IrDA_PULSEDIV2) && ((OPT) <= UARTX_IrDA_PULSEDIV256))
+
+/**
+ * @brief UARTX Configuration Structure definition
+ */
+typedef struct {
+    uint32_t baudRate;            /**< Baud rate. */
+    UARTX_PARITY parity;          /**< Should be:
+                                  - UARTX_PARITY_NONE:.
+                                  - UARTX_PARITY_ODD:.
+                                  - UARTX_PARITY_EVEN:.
+                                  - UARTX_PARITY_SP_1:.
+                                  - UARTX_PARITY_SP_0:. */
+    UARTX_CHAR_LENGTH charLength; /**< Should be:
+                                  - UARTX_DATABIT_5.
+                                  - UARTX_DATABIT_6.
+                                  - UARTX_DATABIT_7.
+                                  - UARTX_DATABIT_8. */
+    UARTX_STOPBITS stopBits;      /**< Should be:
+                                  - UARTX_STOPBITS_1.
+                                  - UARTX_STOPBITS_2. */
+} UARTX_CFG_Type;
+
+/**
+ * @brief UARTX FIFO Configuration Structure definition
+ */
+typedef struct {
+    FunctionalState FIFOResetRxBuf; /**< Should be:
+                                    - ENABLE: Reset Rx FIFO in UART.
+                                    - DISABLE: Do not reset Rx FIFO in UART. */
+    FunctionalState FIFOResetTxBuf; /**< Should be:
+                                    - ENABLE: Reset Tx FIFO in UART.
+                                    - DISABLE: Do not reset Tx FIFO in UART. */
+    FunctionalState FIFODMAMode;    /**< Should be:
+                                    - ENABLE: Enable DMA mode in UART.
+                                    - DISABLE: Disable DMA mode in UART. */
+    UARTX_FIFO_LEVEL FIFOLevel;     /**< Should be:
+                                    - UARTX_FIFO_TRG_1: Rx FIFO trigger level: 1 character.
+                                    - UARTX_FIFO_TRG_4: Rx FIFO trigger level: 4 character.
+                                    - UARTX_FIFO_TRG_8: Rx FIFO trigger level: 8 character.
+                                    - UARTX_FIFO_TRG_14: Rx FIFO trigger level: 14 character. */
+} UARTX_FIFO_CFG_Type;
+
+/**
+ * @brief Auto Baudrate mode configuration type definition
+ */
+typedef struct {
+    UARTX_AB_MODE abMode;        /**< Autobaudrate mode. */
+    FunctionalState autoRestart; /**< Auto Restart state. */
+} UARTX_AB_CFG_Type;
+
+/**
+ * @}
+ */
+
+/* ---------------------------- Public Functions ---------------------------- */
+/** @defgroup ADC_Public_Functions ADC Public Functions
+ * @{
+ */
+
+/**
+ * @brief      Initializes the specified UARTX peripheral.
+ *
+ * This function enables the peripheral power/clock for the selected UART, configures
+ * and resets FIFOs, flushes pending RX data, briefly enables the transmitter
+ * to flush THR, clears interrupt and control registers, programs baud-rate divisors
+ * and configures the Line Control Register.
+ *
+ * @param[in]  UARTx   Pointer to the UART peripheral (UARTx [0,2,3]).
+ * @param[in]  uartCfg Pointer to a UARTX_CFG_Type structure.
+ *
+ * @note:
+ * - Supported UART instances are LPC_UART0, LPC_UART2 and LPC_UART3.
+ * - The function may block while waiting for transmitter (THR) to flush.
+ * - TXEN bit in TER register is disabled at the end of this function.
+ */
+void UARTX_Init(LPC_UARTX_TypeDef* UARTx, const UARTX_CFG_Type* uartCfg);
+
+/**
+ * @brief      De-initializes the specified UARTX peripheral.
+ *
+ * This function disables the UART transmitter, and removes peripheral
+ * power/clock for the selected UART instance.
+ *
+ * @param[in]  UARTx  Pointer to the UART peripheral (UARTx [0,2,3]).
+ *
+ * @note:
+ * - Supported UART instances are LPC_UART0, LPC_UART2 and LPC_UART3.
+ * - Transmitter is disabled via TER.
+ * - The function disables peripheral power using CLKPWR_ConfigPPWR for LPC_UARTx.
+ * - After this call the UART peripheral must be re-initialized before use.
+ */
+void UARTX_DeInit(LPC_UARTX_TypeDef* UARTx);
+
+/**
+ * @brief      Configures the UART FIFO control register (FCR).
+ *
+ * This function composes and writes the FCR value for the specified UART peripheral
+ * to enable/disable FIFOs, reset RX/TX FIFO buffers, select DMA mode and set the
+ * FIFO trigger level.
+ *
+ * @param[in]  UARTx   Pointer to the UART peripheral (UARTx [0,2,3]).
+ * @param[in]  fifoCfg Pointer to a UARTX_FIFO_CFG_Type structure.
+ *
+ * @note:
+ * - Supported UART instances are LPC_UART0, LPC_UART2 and LPC_UART3.
+ */
+void UARTX_FIFOConfig(LPC_UARTX_TypeDef* UARTx, const UARTX_FIFO_CFG_Type* fifoCfg);
+
+/**
+ * @brief      Sends a single byte through the specified UARTX peripheral.
+ *
+ * This function writes one byte to the UART Transmit Holding Register (THR).
+ * The value is masked with UARTX_THR_MASKBIT before being written to ensure
+ * only defined data bits are transmitted. The call returns immediately and
+ * does not poll the line status.
+ *
+ * @param[in]  UARTx  Pointer to the UART peripheral (UARTx [0,2,3]).
+ * @param[in]  byte   Byte value to be transmitted.
+ *
+ * @note:
+ * - Supported UART instances are LPC_UART0, LPC_UART2 and LPC_UART3.
+ * - This function does not wait for the Transmit Holding Register Empty (THRE).
+ */
+void UARTX_SendByte(LPC_UARTX_TypeDef* UARTx, uint8_t byte);
+
+/**
+ * @brief      Receives a single byte from the specified UARTX peripheral.
+ *
+ * This function reads one byte from the UART Receive Buffer Register (RBR).
+ * The value is masked with UARTX_RBR_MASKBIT before being returned to ensure
+ * only defined data bits are received.
+ *
+ * @param[in]  UARTx  Pointer to the UART peripheral (UARTx [0,2,3]).
+ * @return     The received byte.
+ *
+ * @note:
+ * - Supported UART instances are LPC_UART0, LPC_UART2 and LPC_UART3.
+ */
+uint8_t UARTX_ReceiveByte(LPC_UARTX_TypeDef* UARTx);
+
+/**
+ * @brief     Sends a block of data via UARTX peripheral.
+ *
+ * This function sends a block of data via the specified UART peripheral.
+ * Depending on the 'blocking' parameter, the function operates in either
+ * blocking or non-blocking mode. In blocking mode, the function waits until
+ * all data is sent or a timeout occurs. In non-blocking mode, the function
+ * sends as much data as possible without waiting.
+ *
+ * @param UARTx     Pointer to the UART peripheral (UARTx [0,2,3]).
+ * @param txBuff    Pointer to transmit buffer.
+ * @param buffLen   Length of transmit buffer.
+ * @param blocking  Blocking mode enable/disable:
+ *                  - TRUE: Blocking mode enabled.
+ *                  - FALSE: Non-blocking mode.
+ *
+ * @return          Number of bytes sent.
+ *
+ * @note:
+ * - Supported UART instances are LPC_UART0, LPC_UART2 and LPC_UART3.
+ */
+uint32_t UARTX_Send(LPC_UARTX_TypeDef* UARTx, const uint8_t* txBuff, uint32_t buffLen, Bool blocking);
+
+/**
+ * @brief     Receives a block of data via UARTX peripheral.
+ *
+ * This function receives a block of data via the specified UART peripheral.
+ * Depending on the 'blocking' parameter, the function operates in either
+ * blocking or non-blocking mode. In blocking mode, the function waits until
+ * all data is received or a timeout occurs. In non-blocking mode, the function
+ * receives as much data as available without waiting.
+ *
+ * @param UARTx     Pointer to the UART peripheral (UARTx [0,2,3]).
+ * @param rxBuff    Pointer to receive buffer.
+ * @param buffLen   Amount of data to be received (should be less than
+ *                  the size of rxBuff).
+ * @param blocking  Blocking mode enable/disable:
+ *                  - TRUE: Blocking mode enabled.
+ *                  - FALSE: Non-blocking mode.
+ *
+ * @return          Number of bytes successfully received.
+ *
+ * @note:
+ * - Supported UART instances are LPC_UART0, LPC_UART2 and LPC_UART3.
+ */
+uint32_t UARTX_Receive(LPC_UARTX_TypeDef* UARTx, uint8_t* rxBuff, uint32_t buffLen, Bool blocking);
+
+/**
+ * @brief       Get Interrupt Identification value
+ *
+ * @param UARTx Pointer to the UART peripheral (UARTx [0,2,3]).
+ *
+ * @return      Current value of UART UIIR register in UART peripheral.
+ *
+ * @note:
+ * - Supported UART instances are LPC_UART0, LPC_UART2 and LPC_UART3.
+ */
+uint32_t UARTX_GetIntId(LPC_UARTX_TypeDef* UARTx);
+
+/**
+ * @brief       Get Line Status value
+ *
+ * @param UARTx Pointer to the UART peripheral (UARTx [0,2,3]).
+ *
+ * @return      Current value of UART LSR register in UART peripheral.
+ *
+ * @note:
+ * - Supported UART instances are LPC_UART0, LPC_UART2 and LPC_UART3.
+ */
+uint8_t UARTX_GetLineStatus(LPC_UARTX_TypeDef* UARTx);
+
+/**
+ * @brief       Enables or Disables the specified UARTX interrupt.
+ *
+ * @param UARTx   Pointer to the UART peripheral (UARTx [0,2,3]).
+ * @param option  UARTX interrupt type, should be:
+ *                 - UARTX_INT_RBR: RBR Interrupt enable.
+ *                 - UARTX_INT_THRE: THR Interrupt enable.
+ *                 - UARTX_INT_RXLS: RX line status interrupt enable.
+ *                 - UARTX_INT_ABEO: End of auto-baud interrupt enable.
+ *                 - UARTX_INT_ABTO: Time-out of auto-baud interrupt enable.
+ *
+ * @param newState Should be:
+ *                 - ENABLE: Enable this UARTX interrupt type.
+ *                 - DISABLE: Disable this UARTX interrupt type.
+ *
+ * @note:
+ * - Supported UART instances are LPC_UART0, LPC_UART2 and LPC_UART3.
+ */
+void UARTX_IntConfig(LPC_UARTX_TypeDef* UARTx, UARTX_INT option, FunctionalState newState);
+
+/**
+ * @brief       Enable/Disable transmission on UARTX TxD pin
+ *
+ * @param UARTx    Pointer to the UART peripheral (UARTx [0,2,3]).
+ * @param newState Should be:
+ *                 - ENABLE: Enable this function.
+ *                 - DISABLE: Disable this function.
+ *
+ * @note:
+ * - Supported UART instances are LPC_UART0, LPC_UART2 and LPC_UART3.
+ */
+void UARTX_TxCmd(LPC_UARTX_TypeDef* UARTx, FunctionalState newState);
+
+/**
+ * @brief       Check whether if UARTX transmitter is busy or not.
+ *
+ * @param UARTx Pointer to the UART peripheral (UARTx [0,2,3]).
+ *
+ * @return      RESET if UARTX is not busy, otherwise return SET.
+ *
+ * @note:
+ * - Supported UART instances are LPC_UART0, LPC_UART2 and LPC_UART3.
+ */
+FlagStatus UARTX_CheckBusy(LPC_UARTX_TypeDef* UARTx);
+
+/**
+ * @brief       Force a break condition on UARTX TxD pin
+ *
+ * @param UARTx Pointer to the UART peripheral (UARTx [0,2,3]).
+ *
+ * @note:
+ * - Supported UART instances are LPC_UART0, LPC_UART2 and LPC_UART3.
+ */
+void UARTX_ForceBreak(LPC_UARTX_TypeDef* UARTx);
+
+/**
+ * @brief       Clear Auto-baudrate Interrupt Pending
+ *
+ * @param UARTx      Pointer to the UART peripheral (UARTx [0,2,3]).
+ * @param abIntType  Type of auto-baud interrupt, should be:
+ *                    - UARTX_INT_ABEO: End of Auto-baud interrupt.
+ *                    - UARTX_INT_ABTO: Auto-baud time out interrupt.
+ */
+void UARTX_ABClearIntPending(LPC_UARTX_TypeDef* UARTx, UARTX_INT abIntType);
+
+/**
+ * @brief       Enable/Disable Auto-baudrate function
+ *
+ * @param UARTx     Pointer to the UART peripheral (UARTx [0,2,3]).
+ * @param abCfg     Pointer to a UARTX_AB_CFG_Type structure.
+ * @param newState  Should be:
+ *                   - ENABLE: Enable this function.
+ *                   - DISABLE: Disable this function.
+ *
+ * @note:
+ * - Supported UART instances are LPC_UART0, LPC_UART2 and LPC_UART3.
+ */
+void UARTX_ABCmd(LPC_UARTX_TypeDef* UARTx, UARTX_AB_CFG_Type* abCfg, FunctionalState newState);
+
+/**
+ * @brief       Enable/Disable IrDA serial input inversion
+ *
+ * @param UARTx     Pointer to the UART peripheral (UARTx [0,2,3]).
+ * @param newState  Should be:
+ *                   - ENABLE: Enable this function.
+ *                   - DISABLE: Disable this function.
+ * @note:
+ * - Supported UART instances are LPC_UART0, LPC_UART2 and LPC_UART3.
+ */
+void UARTX_IrDAInvtInputCmd(LPC_UARTX_TypeDef* UARTx, FunctionalState newState);
+
+/**
+ * @brief       Enable/Disable IrDA function
+ *
+ * @param UARTx     Pointer to the UART peripheral (UARTx [0,2,3]).
+ * @param newState  Should be:
+ *                   - ENABLE: Enable this function.
+ *                   - DISABLE: Disable this function.
+ * @note:
+ * - Supported UART instances are LPC_UART0, LPC_UART2 and LPC_UART3.
+ */
+void UARTX_IrDACmd(LPC_UARTX_TypeDef* UARTx, FunctionalState newState);
+void UARTX_IrDAPulseDivConfig(LPC_UARTX_TypeDef* UARTx, UARTX_IrDA_PULSE_Type pulseDiv);
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  //LPC17XX_UARTX_H
+
+/**
+ * @}
+ */
+
+/* ------------------------------ End Of File ------------------------------- */

--- a/CMSISv2p00_LPC17xx/Drivers/src/lpc17xx_uart.c
+++ b/CMSISv2p00_LPC17xx/Drivers/src/lpc17xx_uart.c
@@ -1,1366 +1,1366 @@
-/***********************************************************************//**
- * @file        lpc17xx_uart.c
- * @brief        Contains all functions support for UART firmware library on LPC17xx
- * @version        3.0
- * @date        18. June. 2010
- * @author        NXP MCU SW Application Team
- **************************************************************************
- * Software that is described herein is for illustrative purposes only
- * which provides customers with programming information regarding the
- * products. This software is supplied "AS IS" without any warranties.
- * NXP Semiconductors assumes no responsibility or liability for the
- * use of the software, conveys no license or title under any patent,
- * copyright, or mask work right to the product. NXP Semiconductors
- * reserves the right to make changes in the software without
- * notification. NXP Semiconductors also make no representation or
- * warranty that such application will be suitable for the specified
- * use without further testing or modification.
- **********************************************************************/
-
-/* Peripheral group ----------------------------------------------------------- */
-/** @addtogroup UART
- * @{
- */
-
-/* Includes ------------------------------------------------------------------- */
-#include "lpc17xx_uart.h"
-#include "lpc17xx_clkpwr.h"
-
-/* If this source file built with example, the LPC17xx FW library configuration
- * file in each example directory ("lpc17xx_libcfg.h") must be included,
- * otherwise the default FW library configuration file must be included instead
- */
-#ifdef __BUILD_WITH_EXAMPLE__
-#include "lpc17xx_libcfg.h"
-#else
-#include "lpc17xx_libcfg_default.h"
-#endif /* __BUILD_WITH_EXAMPLE__ */
-
-
-#ifdef _UART
-
-/* Private Functions ---------------------------------------------------------- */
-
-static Status uart_set_divisors(LPC_UART_TypeDef *UARTx, uint32_t baudrate);
-
-
-/*********************************************************************//**
- * @brief        Determines best dividers to get a target clock rate
- * @param[in]    UARTx    Pointer to selected UART peripheral, should be:
- *                 - LPC_UART0: UART0 peripheral
- *                 - LPC_UART1: UART1 peripheral
- *                 - LPC_UART2: UART2 peripheral
- *                 - LPC_UART3: UART3 peripheral
- * @param[in]    baudrate Desired UART baud rate.
- * @return         Error status, could be:
- *                 - SUCCESS
- *                 - ERROR
- **********************************************************************/
-static Status uart_set_divisors(LPC_UART_TypeDef *UARTx, uint32_t baudrate)
-{
-    Status errorStatus = ERROR;
-
-    uint32_t uClk = 0;
-    uint32_t calcBaudrate = 0;
-    uint32_t temp = 0;
-
-    uint32_t mulFracDiv, dividerAddFracDiv;
-    uint32_t diviser = 0 ;
-    uint32_t mulFracDivOptimal = 1;
-    uint32_t dividerAddOptimal = 0;
-    uint32_t diviserOptimal = 0;
-
-    uint32_t relativeError = 0;
-    uint32_t relativeOptimalError = 100000;
-
-    /* get UART block clock */
-    if (UARTx == (LPC_UART_TypeDef *)LPC_UART0)
-    {
-        uClk = CLKPWR_GetPCLK (CLKPWR_PCLKSEL_UART0);
-    }
-    else if (UARTx == (LPC_UART_TypeDef *)LPC_UART1)
-    {
-        uClk = CLKPWR_GetPCLK (CLKPWR_PCLKSEL_UART1);
-    }
-    else if (UARTx == (LPC_UART_TypeDef *)LPC_UART2)
-    {
-        uClk = CLKPWR_GetPCLK (CLKPWR_PCLKSEL_UART2);
-    }
-    else if (UARTx == (LPC_UART_TypeDef *)LPC_UART3)
-    {
-        uClk = CLKPWR_GetPCLK (CLKPWR_PCLKSEL_UART3);
-    }
-
-
-    uClk = uClk >> 4; /* div by 16 */
-    /* In the Uart IP block, baud rate is calculated using FDR and DLL-DLM registers
-    * The formula is :
-    * BaudRate= uClk * (mulFracDiv/(mulFracDiv+dividerAddFracDiv) / (16 * (DLL)
-    * It involves floating point calculations. That's the reason the formulae are adjusted with
-    * Multiply and divide method.*/
-    /* The value of mulFracDiv and dividerAddFracDiv should comply to the following expressions:
-    * 0 < mulFracDiv <= 15, 0 <= dividerAddFracDiv <= 15 */
-    for (mulFracDiv = 1 ; mulFracDiv <= 15 ;mulFracDiv++)
-    {
-    for (dividerAddFracDiv = 0 ; dividerAddFracDiv <= 15 ;dividerAddFracDiv++)
-    {
-      temp = (mulFracDiv * uClk) / ((mulFracDiv + dividerAddFracDiv));
-
-      diviser = temp / baudrate;
-      if ((temp % baudrate) > (baudrate / 2))
-        diviser++;
-
-      if (diviser > 2 && diviser < 65536)
-      {
-        calcBaudrate = temp / diviser;
-
-        if (calcBaudrate <= baudrate)
-          relativeError = baudrate - calcBaudrate;
-        else
-          relativeError = calcBaudrate - baudrate;
-
-        if ((relativeError < relativeOptimalError))
-        {
-          mulFracDivOptimal = mulFracDiv ;
-          dividerAddOptimal = dividerAddFracDiv;
-          diviserOptimal = diviser;
-          relativeOptimalError = relativeError;
-          if (relativeError == 0)
-            break;
-        }
-      } /* End of if */
-    } /* end of inner for loop */
-    if (relativeError == 0)
-      break;
-    } /* end of outer for loop  */
-
-    if (relativeOptimalError < ((baudrate * UART_ACCEPTED_BAUDRATE_ERROR)/100))
-    {
-        if (((LPC_UART1_TypeDef *)UARTx) == LPC_UART1)
-        {
-            ((LPC_UART1_TypeDef *)UARTx)->LCR |= UART_LCR_DLAB_EN;
-            ((LPC_UART1_TypeDef *)UARTx)->/*DLIER.*/DLM = UART_LOAD_DLM(diviserOptimal);
-            ((LPC_UART1_TypeDef *)UARTx)->/*RBTHDLR.*/DLL = UART_LOAD_DLL(diviserOptimal);
-            /* Then reset DLAB bit */
-            ((LPC_UART1_TypeDef *)UARTx)->LCR &= (~UART_LCR_DLAB_EN) & UART_LCR_BITMASK;
-            ((LPC_UART1_TypeDef *)UARTx)->FDR = (UART_FDR_MULVAL(mulFracDivOptimal) \
-                    | UART_FDR_DIVADDVAL(dividerAddOptimal)) & UART_FDR_BITMASK;
-        }
-        else
-        {
-            UARTx->LCR |= UART_LCR_DLAB_EN;
-            UARTx->/*DLIER.*/DLM = UART_LOAD_DLM(diviserOptimal);
-            UARTx->/*RBTHDLR.*/DLL = UART_LOAD_DLL(diviserOptimal);
-            /* Then reset DLAB bit */
-            UARTx->LCR &= (~UART_LCR_DLAB_EN) & UART_LCR_BITMASK;
-            UARTx->FDR = (UART_FDR_MULVAL(mulFracDivOptimal) \
-                    | UART_FDR_DIVADDVAL(dividerAddOptimal)) & UART_FDR_BITMASK;
-        }
-        errorStatus = SUCCESS;
-    }
-
-    return errorStatus;
-}
-
-/* End of Private Functions ---------------------------------------------------- */
-
-
-/* Public Functions ----------------------------------------------------------- */
-/** @addtogroup UART_Public_Functions
- * @{
- */
-/* UART Init/DeInit functions -------------------------------------------------*/
-/********************************************************************//**
- * @brief        Initializes the UARTx peripheral according to the specified
- *               parameters in the UART_ConfigStruct.
- * @param[in]    UARTx    UART peripheral selected, should be:
- *               - LPC_UART0: UART0 peripheral
- *                 - LPC_UART1: UART1 peripheral
- *                 - LPC_UART2: UART2 peripheral
- *                 - LPC_UART3: UART3 peripheral
- * @param[in]    UART_ConfigStruct Pointer to a UART_CFG_Type structure
-*                    that contains the configuration information for the
-*                    specified UART peripheral.
- * @return         None
- *********************************************************************/
-void UART_Init(LPC_UART_TypeDef *UARTx, UART_CFG_Type *UART_ConfigStruct)
-{
-    uint32_t tmp;
-
-    // For debug mode
-    CHECK_PARAM(PARAM_UARTx(UARTx));
-    CHECK_PARAM(PARAM_UART_DATABIT(UART_ConfigStruct->Databits));
-    CHECK_PARAM(PARAM_UART_STOPBIT(UART_ConfigStruct->Stopbits));
-    CHECK_PARAM(PARAM_UART_PARITY(UART_ConfigStruct->Parity));
-
-#ifdef _UART0
-    if(UARTx == (LPC_UART_TypeDef *)LPC_UART0)
-    {
-        /* Set up clock and power for UART module */
-        CLKPWR_ConfigPPWR (CLKPWR_PCONP_PCUART0, ENABLE);
-    }
-#endif
-
-#ifdef _UART1
-    if(((LPC_UART1_TypeDef *)UARTx) == LPC_UART1)
-    {
-        /* Set up clock and power for UART module */
-        CLKPWR_ConfigPPWR (CLKPWR_PCONP_PCUART1, ENABLE);
-    }
-#endif
-
-#ifdef _UART2
-    if(UARTx == (LPC_UART_TypeDef *)LPC_UART2)
-    {
-        /* Set up clock and power for UART module */
-        CLKPWR_ConfigPPWR (CLKPWR_PCONP_PCUART2, ENABLE);
-    }
-#endif
-
-#ifdef _UART3
-    if(UARTx == (LPC_UART_TypeDef *)LPC_UART3)
-    {
-        /* Set up clock and power for UART module */
-        CLKPWR_ConfigPPWR (CLKPWR_PCONP_PCUART3, ENABLE);
-    }
-#endif
-
-    if (((LPC_UART1_TypeDef *)UARTx) == LPC_UART1)
-    {
-        /* FIFOs are empty */
-        ((LPC_UART1_TypeDef *)UARTx)->/*IIFCR.*/FCR = ( UART_FCR_FIFO_EN \
-                | UART_FCR_RX_RS | UART_FCR_TX_RS);
-        // Disable FIFO
-        ((LPC_UART1_TypeDef *)UARTx)->/*IIFCR.*/FCR = 0;
-
-        // Dummy reading
-        while (((LPC_UART1_TypeDef *)UARTx)->LSR & UART_LSR_RDR)
-        {
-            tmp = ((LPC_UART1_TypeDef *)UARTx)->/*RBTHDLR.*/RBR;
-        }
-
-        ((LPC_UART1_TypeDef *)UARTx)->TER = UART_TER_TXEN;
-        // Wait for current transmit complete
-        while (!(((LPC_UART1_TypeDef *)UARTx)->LSR & UART_LSR_THRE));
-        // Disable Tx
-        ((LPC_UART1_TypeDef *)UARTx)->TER = 0;
-
-        // Disable interrupt
-        ((LPC_UART1_TypeDef *)UARTx)->/*DLIER.*/IER = 0;
-        // Set LCR to default state
-        ((LPC_UART1_TypeDef *)UARTx)->LCR = 0;
-        // Set ACR to default state
-        ((LPC_UART1_TypeDef *)UARTx)->ACR = 0;
-        // Set Modem Control to default state
-        ((LPC_UART1_TypeDef *)UARTx)->MCR = 0;
-        // Set RS485 control to default state
-        ((LPC_UART1_TypeDef *)UARTx)->RS485CTRL = 0;
-        // Set RS485 delay timer to default state
-        ((LPC_UART1_TypeDef *)UARTx)->RS485DLY = 0;
-        // Set RS485 addr match to default state
-        ((LPC_UART1_TypeDef *)UARTx)->ADRMATCH = 0;
-        //Dummy Reading to Clear Status
-        tmp = ((LPC_UART1_TypeDef *)UARTx)->MSR;
-        tmp = ((LPC_UART1_TypeDef *)UARTx)->LSR;
-    }
-    else
-    {
-        /* FIFOs are empty */
-        UARTx->/*IIFCR.*/FCR = ( UART_FCR_FIFO_EN | UART_FCR_RX_RS | UART_FCR_TX_RS);
-        // Disable FIFO
-        UARTx->/*IIFCR.*/FCR = 0;
-
-        // Dummy reading
-        while (UARTx->LSR & UART_LSR_RDR)
-        {
-            tmp = UARTx->/*RBTHDLR.*/RBR;
-        }
-
-        UARTx->TER = UART_TER_TXEN;
-        // Wait for current transmit complete
-        while (!(UARTx->LSR & UART_LSR_THRE));
-        // Disable Tx
-        UARTx->TER = 0;
-
-        // Disable interrupt
-        UARTx->/*DLIER.*/IER = 0;
-        // Set LCR to default state
-        UARTx->LCR = 0;
-        // Set ACR to default state
-        UARTx->ACR = 0;
-        // Dummy reading
-        tmp = UARTx->LSR;
-    }
-
-    if (UARTx == LPC_UART3)
-    {
-        // Set IrDA to default state
-        UARTx->ICR = 0;
-    }
-
-    // Set Line Control register ----------------------------
-
-    uart_set_divisors(UARTx, (UART_ConfigStruct->Baud_rate));
-
-    if (((LPC_UART1_TypeDef *)UARTx) == LPC_UART1)
-    {
-        tmp = (((LPC_UART1_TypeDef *)UARTx)->LCR & (UART_LCR_DLAB_EN | UART_LCR_BREAK_EN)) \
-                & UART_LCR_BITMASK;
-    }
-    else
-    {
-        tmp = (UARTx->LCR & (UART_LCR_DLAB_EN | UART_LCR_BREAK_EN)) & UART_LCR_BITMASK;
-    }
-
-    switch (UART_ConfigStruct->Databits){
-    case UART_DATABIT_5:
-        tmp |= UART_LCR_WLEN5;
-        break;
-    case UART_DATABIT_6:
-        tmp |= UART_LCR_WLEN6;
-        break;
-    case UART_DATABIT_7:
-        tmp |= UART_LCR_WLEN7;
-        break;
-    case UART_DATABIT_8:
-    default:
-        tmp |= UART_LCR_WLEN8;
-        break;
-    }
-
-    if (UART_ConfigStruct->Parity == UART_PARITY_NONE)
-    {
-        // Do nothing...
-    }
-    else
-    {
-        tmp |= UART_LCR_PARITY_EN;
-        switch (UART_ConfigStruct->Parity)
-        {
-        case UART_PARITY_ODD:
-            tmp |= UART_LCR_PARITY_ODD;
-            break;
-
-        case UART_PARITY_EVEN:
-            tmp |= UART_LCR_PARITY_EVEN;
-            break;
-
-        case UART_PARITY_SP_1:
-            tmp |= UART_LCR_PARITY_F_1;
-            break;
-
-        case UART_PARITY_SP_0:
-            tmp |= UART_LCR_PARITY_F_0;
-            break;
-        default:
-            break;
-        }
-    }
-
-    switch (UART_ConfigStruct->Stopbits){
-    case UART_STOPBIT_2:
-        tmp |= UART_LCR_STOPBIT_SEL;
-        break;
-    case UART_STOPBIT_1:
-    default:
-        // Do no thing
-        break;
-    }
-
-
-    // Write back to LCR, configure FIFO and Disable Tx
-    if (((LPC_UART1_TypeDef *)UARTx) ==  LPC_UART1)
-    {
-        ((LPC_UART1_TypeDef *)UARTx)->LCR = (uint8_t)(tmp & UART_LCR_BITMASK);
-    }
-    else
-    {
-        UARTx->LCR = (uint8_t)(tmp & UART_LCR_BITMASK);
-    }
-}
-
-/*********************************************************************//**
- * @brief        De-initializes the UARTx peripheral registers to their
- *                  default reset values.
- * @param[in]    UARTx    UART peripheral selected, should be:
- *               - LPC_UART0: UART0 peripheral
- *                 - LPC_UART1: UART1 peripheral
- *                 - LPC_UART2: UART2 peripheral
- *                 - LPC_UART3: UART3 peripheral
- * @return         None
- **********************************************************************/
-void UART_DeInit(LPC_UART_TypeDef* UARTx)
-{
-    // For debug mode
-    CHECK_PARAM(PARAM_UARTx(UARTx));
-
-    UART_TxCmd(UARTx, DISABLE);
-
-#ifdef _UART0
-    if (UARTx == (LPC_UART_TypeDef *)LPC_UART0)
-    {
-        /* Set up clock and power for UART module */
-        CLKPWR_ConfigPPWR (CLKPWR_PCONP_PCUART0, DISABLE);
-    }
-#endif
-
-#ifdef _UART1
-    if (((LPC_UART1_TypeDef *)UARTx) == LPC_UART1)
-    {
-        /* Set up clock and power for UART module */
-        CLKPWR_ConfigPPWR (CLKPWR_PCONP_PCUART1, DISABLE);
-    }
-#endif
-
-#ifdef _UART2
-    if (UARTx == (LPC_UART_TypeDef *)LPC_UART2)
-    {
-        /* Set up clock and power for UART module */
-        CLKPWR_ConfigPPWR (CLKPWR_PCONP_PCUART2, DISABLE);
-    }
-#endif
-
-#ifdef _UART3
-    if (UARTx == (LPC_UART_TypeDef *)LPC_UART3)
-    {
-        /* Set up clock and power for UART module */
-        CLKPWR_ConfigPPWR (CLKPWR_PCONP_PCUART3, DISABLE);
-    }
-#endif
-}
-
-/*****************************************************************************//**
-* @brief        Fills each UART_InitStruct member with its default value:
-*                 - 9600 bps
-*                 - 8-bit data
-*                 - 1 Stopbit
-*                 - None Parity
-* @param[in]    UART_InitStruct Pointer to a UART_CFG_Type structure
-*                    which will be initialized.
-* @return        None
-*******************************************************************************/
-void UART_ConfigStructInit(UART_CFG_Type *UART_InitStruct)
-{
-    UART_InitStruct->Baud_rate = 9600;
-    UART_InitStruct->Databits = UART_DATABIT_8;
-    UART_InitStruct->Parity = UART_PARITY_NONE;
-    UART_InitStruct->Stopbits = UART_STOPBIT_1;
-}
-
-/* UART Send/Recieve functions -------------------------------------------------*/
-/*********************************************************************//**
- * @brief        Transmit a single data through UART peripheral
- * @param[in]    UARTx    UART peripheral selected, should be:
- *               - LPC_UART0: UART0 peripheral
- *                 - LPC_UART1: UART1 peripheral
- *                 - LPC_UART2: UART2 peripheral
- *                 - LPC_UART3: UART3 peripheral
- * @param[in]    Data    Data to transmit (must be 8-bit long)
- * @return         None
- **********************************************************************/
-void UART_SendByte(LPC_UART_TypeDef* UARTx, uint8_t Data)
-{
-    CHECK_PARAM(PARAM_UARTx(UARTx));
-
-    if (((LPC_UART1_TypeDef *)UARTx) == LPC_UART1)
-    {
-        ((LPC_UART1_TypeDef *)UARTx)->/*RBTHDLR.*/THR = Data & UART_THR_MASKBIT;
-    }
-    else
-    {
-        UARTx->/*RBTHDLR.*/THR = Data & UART_THR_MASKBIT;
-    }
-
-}
-
-
-/*********************************************************************//**
- * @brief        Receive a single data from UART peripheral
- * @param[in]    UARTx    UART peripheral selected, should be:
- *              - LPC_UART0: UART0 peripheral
- *                 - LPC_UART1: UART1 peripheral
- *                 - LPC_UART2: UART2 peripheral
- *                 - LPC_UART3: UART3 peripheral
- * @return         Data received
- **********************************************************************/
-uint8_t UART_ReceiveByte(LPC_UART_TypeDef* UARTx)
-{
-    CHECK_PARAM(PARAM_UARTx(UARTx));
-
-    if (((LPC_UART1_TypeDef *)UARTx) == LPC_UART1)
-    {
-        return (((LPC_UART1_TypeDef *)UARTx)->/*RBTHDLR.*/RBR & UART_RBR_MASKBIT);
-    }
-    else
-    {
-        return (UARTx->/*RBTHDLR.*/RBR & UART_RBR_MASKBIT);
-    }
-}
-
-/*********************************************************************//**
- * @brief        Send a block of data via UART peripheral
- * @param[in]    UARTx    Selected UART peripheral used to send data, should be:
- *               - LPC_UART0: UART0 peripheral
- *                 - LPC_UART1: UART1 peripheral
- *                 - LPC_UART2: UART2 peripheral
- *                 - LPC_UART3: UART3 peripheral
- * @param[in]    txbuf     Pointer to Transmit buffer
- * @param[in]    buflen     Length of Transmit buffer
- * @param[in]     flag     Flag used in  UART transfer, should be
- *                         NONE_BLOCKING or BLOCKING
- * @return         Number of bytes sent.
- *
- * Note: when using UART in BLOCKING mode, a time-out condition is used
- * via defined symbol UART_BLOCKING_TIMEOUT.
- **********************************************************************/
-uint32_t UART_Send(LPC_UART_TypeDef *UARTx, uint8_t *txbuf,
-        uint32_t buflen, TRANSFER_BLOCK_Type flag)
-{
-    uint32_t bToSend, bSent, timeOut, fifo_cnt;
-    uint8_t *pChar = txbuf;
-
-    bToSend = buflen;
-
-    // blocking mode
-    if (flag == BLOCKING) {
-        bSent = 0;
-        while (bToSend){
-            timeOut = UART_BLOCKING_TIMEOUT;
-            // Wait for THR empty with timeout
-            while (!(UARTx->LSR & UART_LSR_THRE)) {
-                if (timeOut == 0) break;
-                timeOut--;
-            }
-            // Time out!
-            if(timeOut == 0) break;
-            fifo_cnt = UART_TX_FIFO_SIZE;
-            while (fifo_cnt && bToSend){
-                UART_SendByte(UARTx, (*pChar++));
-                fifo_cnt--;
-                bToSend--;
-                bSent++;
-            }
-        }
-    }
-    // None blocking mode
-    else {
-        bSent = 0;
-        while (bToSend) {
-            if (!(UARTx->LSR & UART_LSR_THRE)){
-                break;
-            }
-            fifo_cnt = UART_TX_FIFO_SIZE;
-            while (fifo_cnt && bToSend) {
-                UART_SendByte(UARTx, (*pChar++));
-                bToSend--;
-                fifo_cnt--;
-                bSent++;
-            }
-        }
-    }
-    return bSent;
-}
-
-/*********************************************************************//**
- * @brief        Receive a block of data via UART peripheral
- * @param[in]    UARTx    Selected UART peripheral used to send data,
- *                 should be:
- *               - LPC_UART0: UART0 peripheral
- *                 - LPC_UART1: UART1 peripheral
- *                 - LPC_UART2: UART2 peripheral
- *                 - LPC_UART3: UART3 peripheral
- * @param[out]    rxbuf     Pointer to Received buffer
- * @param[in]    buflen     Length of Received buffer
- * @param[in]     flag     Flag mode, should be NONE_BLOCKING or BLOCKING
-
- * @return         Number of bytes received
- *
- * Note: when using UART in BLOCKING mode, a time-out condition is used
- * via defined symbol UART_BLOCKING_TIMEOUT.
- **********************************************************************/
-uint32_t UART_Receive(LPC_UART_TypeDef *UARTx, uint8_t *rxbuf, \
-        uint32_t buflen, TRANSFER_BLOCK_Type flag)
-{
-    uint32_t bToRecv, bRecv, timeOut;
-    uint8_t *pChar = rxbuf;
-
-    bToRecv = buflen;
-
-    // Blocking mode
-    if (flag == BLOCKING) {
-        bRecv = 0;
-        while (bToRecv){
-            timeOut = UART_BLOCKING_TIMEOUT;
-            while (!(UARTx->LSR & UART_LSR_RDR)){
-                if (timeOut == 0) break;
-                timeOut--;
-            }
-            // Time out!
-            if(timeOut == 0) break;
-            // Get data from the buffer
-            (*pChar++) = UART_ReceiveByte(UARTx);
-            bToRecv--;
-            bRecv++;
-        }
-    }
-    // None blocking mode
-    else {
-        bRecv = 0;
-        while (bToRecv) {
-            if (!(UARTx->LSR & UART_LSR_RDR)) {
-                break;
-            } else {
-                (*pChar++) = UART_ReceiveByte(UARTx);
-                bRecv++;
-                bToRecv--;
-            }
-        }
-    }
-    return bRecv;
-}
-
-/*********************************************************************//**
- * @brief        Force BREAK character on UART line, output pin UARTx TXD is
-                forced to logic 0.
- * @param[in]    UARTx    UART peripheral selected, should be:
- *              - LPC_UART0: UART0 peripheral
- *                 - LPC_UART1: UART1 peripheral
- *                 - LPC_UART2: UART2 peripheral
- *                 - LPC_UART3: UART3 peripheral
- * @return         None
- **********************************************************************/
-void UART_ForceBreak(LPC_UART_TypeDef* UARTx)
-{
-    CHECK_PARAM(PARAM_UARTx(UARTx));
-
-    if (((LPC_UART1_TypeDef *)UARTx) == LPC_UART1)
-    {
-        ((LPC_UART1_TypeDef *)UARTx)->LCR |= UART_LCR_BREAK_EN;
-    }
-    else
-    {
-        UARTx->LCR |= UART_LCR_BREAK_EN;
-    }
-}
-
-
-/********************************************************************//**
- * @brief         Enable or disable specified UART interrupt.
- * @param[in]    UARTx    UART peripheral selected, should be
- *              - LPC_UART0: UART0 peripheral
- *                 - LPC_UART1: UART1 peripheral
- *                 - LPC_UART2: UART2 peripheral
- *                 - LPC_UART3: UART3 peripheral
- * @param[in]    UARTIntCfg    Specifies the interrupt flag,
- *                 should be one of the following:
-                - UART_INTCFG_RBR     :  RBR Interrupt enable
-                - UART_INTCFG_THRE     :  THR Interrupt enable
-                - UART_INTCFG_RLS     :  RX line status interrupt enable
-                - UART1_INTCFG_MS    :  Modem status interrupt enable (UART1 only)
-                - UART1_INTCFG_CTS    :  CTS1 signal transition interrupt enable (UART1 only)
-                - UART_INTCFG_ABEO     :  Enables the end of auto-baud interrupt
-                - UART_INTCFG_ABTO     :  Enables the auto-baud time-out interrupt
- * @param[in]    NewState New state of specified UART interrupt type,
- *                 should be:
- *                 - ENALBE: Enable this UART interrupt type.
-*                 - DISALBE: Disable this UART interrupt type.
- * @return         None
- *********************************************************************/
-void UART_IntConfig(LPC_UART_TypeDef *UARTx, UART_INT_Type UARTIntCfg, FunctionalState NewState)
-{
-    uint32_t tmp = 0;
-
-    CHECK_PARAM(PARAM_UARTx(UARTx));
-    CHECK_PARAM(PARAM_FUNCTIONALSTATE(NewState));
-
-    switch(UARTIntCfg){
-        case UART_INTCFG_RBR:
-            tmp = UART_IER_RBRINT_EN;
-            break;
-        case UART_INTCFG_THRE:
-            tmp = UART_IER_THREINT_EN;
-            break;
-        case UART_INTCFG_RLS:
-            tmp = UART_IER_RLSINT_EN;
-            break;
-        case UART1_INTCFG_MS:
-            tmp = UART1_IER_MSINT_EN;
-            break;
-        case UART1_INTCFG_CTS:
-            tmp = UART1_IER_CTSINT_EN;
-            break;
-        case UART_INTCFG_ABEO:
-            tmp = UART_IER_ABEOINT_EN;
-            break;
-        case UART_INTCFG_ABTO:
-            tmp = UART_IER_ABTOINT_EN;
-            break;
-    }
-
-    if ((LPC_UART1_TypeDef *) UARTx == LPC_UART1)
-    {
-        CHECK_PARAM((PARAM_UART_INTCFG(UARTIntCfg)) || (PARAM_UART1_INTCFG(UARTIntCfg)));
-    }
-    else
-    {
-        CHECK_PARAM(PARAM_UART_INTCFG(UARTIntCfg));
-    }
-
-    if (NewState == ENABLE)
-    {
-        if ((LPC_UART1_TypeDef *) UARTx == LPC_UART1)
-        {
-            ((LPC_UART1_TypeDef *)UARTx)->/*DLIER.*/IER |= tmp;
-        }
-        else
-        {
-            UARTx->/*DLIER.*/IER |= tmp;
-        }
-    }
-    else
-    {
-        if ((LPC_UART1_TypeDef *) UARTx == LPC_UART1)
-        {
-            ((LPC_UART1_TypeDef *)UARTx)->/*DLIER.*/IER &= (~tmp) & UART1_IER_BITMASK;
-        }
-        else
-        {
-            UARTx->/*DLIER.*/IER &= (~tmp) & UART_IER_BITMASK;
-        }
-    }
-}
-
-
-/********************************************************************//**
- * @brief         Get current value of Line Status register in UART peripheral.
- * @param[in]    UARTx    UART peripheral selected, should be:
- *              - LPC_UART0: UART0 peripheral
- *                 - LPC_UART1: UART1 peripheral
- *                 - LPC_UART2: UART2 peripheral
- *                 - LPC_UART3: UART3 peripheral
- * @return        Current value of Line Status register in UART peripheral.
- * Note:    The return value of this function must be ANDed with each member in
- *             UART_LS_Type enumeration to determine current flag status
- *             corresponding to each Line status type. Because some flags in
- *             Line Status register will be cleared after reading, the next reading
- *             Line Status register could not be correct. So this function used to
- *             read Line status register in one time only, then the return value
- *             used to check all flags.
- *********************************************************************/
-uint8_t UART_GetLineStatus(LPC_UART_TypeDef* UARTx)
-{
-    CHECK_PARAM(PARAM_UARTx(UARTx));
-
-    if (((LPC_UART1_TypeDef *)UARTx) == LPC_UART1)
-    {
-        return ((((LPC_UART1_TypeDef *)LPC_UART1)->LSR) & UART_LSR_BITMASK);
-    }
-    else
-    {
-        return ((UARTx->LSR) & UART_LSR_BITMASK);
-    }
-}
-
-/********************************************************************//**
- * @brief         Get Interrupt Identification value
- * @param[in]    UARTx    UART peripheral selected, should be:
- *              - LPC_UART0: UART0 peripheral
- *                 - LPC_UART1: UART1 peripheral
- *                 - LPC_UART2: UART2 peripheral
- *                 - LPC_UART3: UART3 peripheral
- * @return        Current value of UART UIIR register in UART peripheral.
- *********************************************************************/
-uint32_t UART_GetIntId(LPC_UART_TypeDef* UARTx)
-{
-    CHECK_PARAM(PARAM_UARTx(UARTx));
-    return (UARTx->IIR & 0x03CF);
-}
-
-/*********************************************************************//**
- * @brief        Check whether if UART is busy or not
- * @param[in]    UARTx    UART peripheral selected, should be:
- *              - LPC_UART0: UART0 peripheral
- *                 - LPC_UART1: UART1 peripheral
- *                 - LPC_UART2: UART2 peripheral
- *                 - LPC_UART3: UART3 peripheral
- * @return        RESET if UART is not busy, otherwise return SET.
- **********************************************************************/
-FlagStatus UART_CheckBusy(LPC_UART_TypeDef *UARTx)
-{
-    if (UARTx->LSR & UART_LSR_TEMT){
-        return RESET;
-    } else {
-        return SET;
-    }
-}
-
-
-/*********************************************************************//**
- * @brief        Configure FIFO function on selected UART peripheral
- * @param[in]    UARTx    UART peripheral selected, should be:
- *              - LPC_UART0: UART0 peripheral
- *                 - LPC_UART1: UART1 peripheral
- *                 - LPC_UART2: UART2 peripheral
- *                 - LPC_UART3: UART3 peripheral
- * @param[in]    FIFOCfg    Pointer to a UART_FIFO_CFG_Type Structure that
- *                         contains specified information about FIFO configuration
- * @return         none
- **********************************************************************/
-void UART_FIFOConfig(LPC_UART_TypeDef *UARTx, UART_FIFO_CFG_Type *FIFOCfg)
-{
-    uint8_t tmp = 0;
-
-    CHECK_PARAM(PARAM_UARTx(UARTx));
-    CHECK_PARAM(PARAM_UART_FIFO_LEVEL(FIFOCfg->FIFO_Level));
-    CHECK_PARAM(PARAM_FUNCTIONALSTATE(FIFOCfg->FIFO_DMAMode));
-    CHECK_PARAM(PARAM_FUNCTIONALSTATE(FIFOCfg->FIFO_ResetRxBuf));
-    CHECK_PARAM(PARAM_FUNCTIONALSTATE(FIFOCfg->FIFO_ResetTxBuf));
-
-    tmp |= UART_FCR_FIFO_EN;
-    switch (FIFOCfg->FIFO_Level){
-    case UART_FIFO_TRGLEV0:
-        tmp |= UART_FCR_TRG_LEV0;
-        break;
-    case UART_FIFO_TRGLEV1:
-        tmp |= UART_FCR_TRG_LEV1;
-        break;
-    case UART_FIFO_TRGLEV2:
-        tmp |= UART_FCR_TRG_LEV2;
-        break;
-    case UART_FIFO_TRGLEV3:
-    default:
-        tmp |= UART_FCR_TRG_LEV3;
-        break;
-    }
-
-    if (FIFOCfg->FIFO_ResetTxBuf == ENABLE)
-    {
-        tmp |= UART_FCR_TX_RS;
-    }
-    if (FIFOCfg->FIFO_ResetRxBuf == ENABLE)
-    {
-        tmp |= UART_FCR_RX_RS;
-    }
-    if (FIFOCfg->FIFO_DMAMode == ENABLE)
-    {
-        tmp |= UART_FCR_DMAMODE_SEL;
-    }
-
-
-    //write to FIFO control register
-    if (((LPC_UART1_TypeDef *)UARTx) == LPC_UART1)
-    {
-        ((LPC_UART1_TypeDef *)UARTx)->/*IIFCR.*/FCR = tmp & UART_FCR_BITMASK;
-    }
-    else
-    {
-        UARTx->/*IIFCR.*/FCR = tmp & UART_FCR_BITMASK;
-    }
-}
-
-/*****************************************************************************//**
-* @brief        Fills each UART_FIFOInitStruct member with its default value:
-*                 - FIFO_DMAMode = DISABLE
-*                 - FIFO_Level = UART_FIFO_TRGLEV0
-*                 - FIFO_ResetRxBuf = ENABLE
-*                 - FIFO_ResetTxBuf = ENABLE
-*                 - FIFO_State = ENABLE
-
-* @param[in]    UART_FIFOInitStruct Pointer to a UART_FIFO_CFG_Type structure
-*                    which will be initialized.
-* @return        None
-*******************************************************************************/
-void UART_FIFOConfigStructInit(UART_FIFO_CFG_Type *UART_FIFOInitStruct)
-{
-    UART_FIFOInitStruct->FIFO_DMAMode = DISABLE;
-    UART_FIFOInitStruct->FIFO_Level = UART_FIFO_TRGLEV0;
-    UART_FIFOInitStruct->FIFO_ResetRxBuf = ENABLE;
-    UART_FIFOInitStruct->FIFO_ResetTxBuf = ENABLE;
-}
-
-
-/*********************************************************************//**
- * @brief        Start/Stop Auto Baudrate activity
- * @param[in]    UARTx    UART peripheral selected, should be
- *               - LPC_UART0: UART0 peripheral
- *                 - LPC_UART1: UART1 peripheral
- *                 - LPC_UART2: UART2 peripheral
- *                 - LPC_UART3: UART3 peripheral
- * @param[in]    ABConfigStruct    A pointer to UART_AB_CFG_Type structure that
- *                                 contains specified information about UART
- *                                 auto baudrate configuration
- * @param[in]    NewState New State of Auto baudrate activity, should be:
- *                 - ENABLE: Start this activity
- *                - DISABLE: Stop this activity
- * Note:        Auto-baudrate mode enable bit will be cleared once this mode
- *                 completed.
- * @return         none
- **********************************************************************/
-void UART_ABCmd(LPC_UART_TypeDef *UARTx, UART_AB_CFG_Type *ABConfigStruct, \
-                FunctionalState NewState)
-{
-    uint32_t tmp;
-
-    CHECK_PARAM(PARAM_UARTx(UARTx));
-    CHECK_PARAM(PARAM_FUNCTIONALSTATE(NewState));
-
-    tmp = 0;
-    if (NewState == ENABLE) {
-        if (ABConfigStruct->ABMode == UART_AUTOBAUD_MODE1){
-            tmp |= UART_ACR_MODE;
-        }
-        if (ABConfigStruct->AutoRestart == ENABLE){
-            tmp |= UART_ACR_AUTO_RESTART;
-        }
-    }
-
-    if (((LPC_UART1_TypeDef *)UARTx) == LPC_UART1)
-    {
-        if (NewState == ENABLE)
-        {
-            // Clear DLL and DLM value
-            ((LPC_UART1_TypeDef *)UARTx)->LCR |= UART_LCR_DLAB_EN;
-            ((LPC_UART1_TypeDef *)UARTx)->DLL = 0;
-            ((LPC_UART1_TypeDef *)UARTx)->DLM = 0;
-            ((LPC_UART1_TypeDef *)UARTx)->LCR &= ~UART_LCR_DLAB_EN;
-            // FDR value must be reset to default value
-            ((LPC_UART1_TypeDef *)UARTx)->FDR = 0x10;
-            ((LPC_UART1_TypeDef *)UARTx)->ACR = UART_ACR_START | tmp;
-        }
-        else
-        {
-            ((LPC_UART1_TypeDef *)UARTx)->ACR = 0;
-        }
-    }
-    else
-    {
-        if (NewState == ENABLE)
-        {
-            // Clear DLL and DLM value
-            UARTx->LCR |= UART_LCR_DLAB_EN;
-            UARTx->DLL = 0;
-            UARTx->DLM = 0;
-            UARTx->LCR &= ~UART_LCR_DLAB_EN;
-            // FDR value must be reset to default value
-            UARTx->FDR = 0x10;
-            UARTx->ACR = UART_ACR_START | tmp;
-        }
-        else
-        {
-            UARTx->ACR = 0;
-        }
-    }
-}
-
-/*********************************************************************//**
- * @brief        Clear Autobaud Interrupt Pending
- * @param[in]    UARTx    UART peripheral selected, should be
- *               - LPC_UART0: UART0 peripheral
- *                 - LPC_UART1: UART1 peripheral
- *                 - LPC_UART2: UART2 peripheral
- *                 - LPC_UART3: UART3 peripheral
- * @param[in]    ABIntType    type of auto-baud interrupt, should be:
- *                 - UART_AUTOBAUD_INTSTAT_ABEO: End of Auto-baud interrupt
- *                 - UART_AUTOBAUD_INTSTAT_ABTO: Auto-baud time out interrupt
- * @return         none
- **********************************************************************/
-void UART_ABClearIntPending(LPC_UART_TypeDef *UARTx, UART_ABEO_Type ABIntType)
-{
-    CHECK_PARAM(PARAM_UARTx(UARTx));
-    if (((LPC_UART1_TypeDef *)UARTx) == LPC_UART1)
-    {
-        UARTx->ACR |= ABIntType;
-    }
-    else
-        UARTx->ACR |= ABIntType;
-}
-
-/*********************************************************************//**
- * @brief        Enable/Disable transmission on UART TxD pin
- * @param[in]    UARTx    UART peripheral selected, should be:
- *               - LPC_UART0: UART0 peripheral
- *                 - LPC_UART1: UART1 peripheral
- *                 - LPC_UART2: UART2 peripheral
- *                 - LPC_UART3: UART3 peripheral
- * @param[in]    NewState New State of Tx transmission function, should be:
- *                 - ENABLE: Enable this function
-                - DISABLE: Disable this function
- * @return none
- **********************************************************************/
-void UART_TxCmd(LPC_UART_TypeDef *UARTx, FunctionalState NewState)
-{
-    CHECK_PARAM(PARAM_UARTx(UARTx));
-    CHECK_PARAM(PARAM_FUNCTIONALSTATE(NewState));
-
-    if (NewState == ENABLE)
-    {
-        if (((LPC_UART1_TypeDef *)UARTx) == LPC_UART1)
-        {
-            ((LPC_UART1_TypeDef *)UARTx)->TER |= UART_TER_TXEN;
-        }
-        else
-        {
-            UARTx->TER |= UART_TER_TXEN;
-        }
-    }
-    else
-    {
-        if (((LPC_UART1_TypeDef *)UARTx) == LPC_UART1)
-        {
-            ((LPC_UART1_TypeDef *)UARTx)->TER &= (~UART_TER_TXEN) & UART_TER_BITMASK;
-        }
-        else
-        {
-            UARTx->TER &= (~UART_TER_TXEN) & UART_TER_BITMASK;
-        }
-    }
-}
-
-/* UART IrDA functions ---------------------------------------------------*/
-
-#ifdef _UART3
-
-/*********************************************************************//**
- * @brief        Enable or disable inverting serial input function of IrDA
- *                 on UART peripheral.
- * @param[in]    UARTx UART peripheral selected, should be LPC_UART3 (only)
- * @param[in]    NewState New state of inverting serial input, should be:
- *                 - ENABLE: Enable this function.
- *                 - DISABLE: Disable this function.
- * @return none
- **********************************************************************/
-void UART_IrDAInvtInputCmd(LPC_UART_TypeDef* UARTx, FunctionalState NewState)
-{
-    CHECK_PARAM(PARAM_UART_IrDA(UARTx));
-    CHECK_PARAM(PARAM_FUNCTIONALSTATE(NewState));
-
-    if (NewState == ENABLE)
-    {
-        UARTx->ICR |= UART_ICR_IRDAINV;
-    }
-    else if (NewState == DISABLE)
-    {
-        UARTx->ICR &= (~UART_ICR_IRDAINV) & UART_ICR_BITMASK;
-    }
-}
-
-
-/*********************************************************************//**
- * @brief        Enable or disable IrDA function on UART peripheral.
- * @param[in]    UARTx UART peripheral selected, should be LPC_UART3 (only)
- * @param[in]    NewState New state of IrDA function, should be:
- *                 - ENABLE: Enable this function.
- *                 - DISABLE: Disable this function.
- * @return none
- **********************************************************************/
-void UART_IrDACmd(LPC_UART_TypeDef* UARTx, FunctionalState NewState)
-{
-    CHECK_PARAM(PARAM_UART_IrDA(UARTx));
-    CHECK_PARAM(PARAM_FUNCTIONALSTATE(NewState));
-
-    if (NewState == ENABLE)
-    {
-        UARTx->ICR |= UART_ICR_IRDAEN;
-    }
-    else
-    {
-        UARTx->ICR &= (~UART_ICR_IRDAEN) & UART_ICR_BITMASK;
-    }
-}
-
-
-/*********************************************************************//**
- * @brief        Configure Pulse divider for IrDA function on UART peripheral.
- * @param[in]    UARTx UART peripheral selected, should be LPC_UART3 (only)
- * @param[in]    PulseDiv Pulse Divider value from Peripheral clock,
- *                 should be one of the following:
-                - UART_IrDA_PULSEDIV2     : Pulse width = 2 * Tpclk
-                - UART_IrDA_PULSEDIV4     : Pulse width = 4 * Tpclk
-                - UART_IrDA_PULSEDIV8     : Pulse width = 8 * Tpclk
-                - UART_IrDA_PULSEDIV16     : Pulse width = 16 * Tpclk
-                - UART_IrDA_PULSEDIV32     : Pulse width = 32 * Tpclk
-                - UART_IrDA_PULSEDIV64     : Pulse width = 64 * Tpclk
-                - UART_IrDA_PULSEDIV128 : Pulse width = 128 * Tpclk
-                - UART_IrDA_PULSEDIV256 : Pulse width = 256 * Tpclk
-
- * @return none
- **********************************************************************/
-void UART_IrDAPulseDivConfig(LPC_UART_TypeDef *UARTx, UART_IrDA_PULSE_Type PulseDiv)
-{
-    uint32_t tmp, tmp1;
-    CHECK_PARAM(PARAM_UART_IrDA(UARTx));
-    CHECK_PARAM(PARAM_UART_IrDA_PULSEDIV(PulseDiv));
-
-    tmp1 = UART_ICR_PULSEDIV(PulseDiv);
-    tmp = UARTx->ICR & (~UART_ICR_PULSEDIV(7));
-    tmp |= tmp1 | UART_ICR_FIXPULSE_EN;
-    UARTx->ICR = tmp & UART_ICR_BITMASK;
-}
-
-#endif
-
-
-/* UART1 FullModem function ---------------------------------------------*/
-
-#ifdef _UART1
-
-/*********************************************************************//**
- * @brief        Force pin DTR/RTS corresponding to given state (Full modem mode)
- * @param[in]    UARTx    LPC_UART1 (only)
- * @param[in]    Pin    Pin that NewState will be applied to, should be:
- *                 - UART1_MODEM_PIN_DTR: DTR pin.
- *                 - UART1_MODEM_PIN_RTS: RTS pin.
- * @param[in]    NewState New State of DTR/RTS pin, should be:
- *                 - INACTIVE: Force the pin to inactive signal.
-                - ACTIVE: Force the pin to active signal.
- * @return none
- **********************************************************************/
-void UART_FullModemForcePinState(LPC_UART1_TypeDef *UARTx, UART_MODEM_PIN_Type Pin, \
-                            UART1_SignalState NewState)
-{
-    uint8_t tmp = 0;
-
-    CHECK_PARAM(PARAM_UART1_MODEM(UARTx));
-    CHECK_PARAM(PARAM_UART1_MODEM_PIN(Pin));
-    CHECK_PARAM(PARAM_UART1_SIGNALSTATE(NewState));
-
-    switch (Pin){
-    case UART1_MODEM_PIN_DTR:
-        tmp = UART1_MCR_DTR_CTRL;
-        break;
-    case UART1_MODEM_PIN_RTS:
-        tmp = UART1_MCR_RTS_CTRL;
-        break;
-    default:
-        break;
-    }
-
-    if (NewState == ACTIVE){
-        UARTx->MCR |= tmp;
-    } else {
-        UARTx->MCR &= (~tmp) & UART1_MCR_BITMASK;
-    }
-}
-
-
-/*********************************************************************//**
- * @brief        Configure Full Modem mode for UART peripheral
- * @param[in]    UARTx    LPC_UART1 (only)
- * @param[in]    Mode Full Modem mode, should be:
- *                 - UART1_MODEM_MODE_LOOPBACK: Loop back mode.
- *                 - UART1_MODEM_MODE_AUTO_RTS: Auto-RTS mode.
- *                 - UART1_MODEM_MODE_AUTO_CTS: Auto-CTS mode.
- * @param[in]    NewState New State of this mode, should be:
- *                 - ENABLE: Enable this mode.
-                - DISABLE: Disable this mode.
- * @return none
- **********************************************************************/
-void UART_FullModemConfigMode(LPC_UART1_TypeDef *UARTx, UART_MODEM_MODE_Type Mode, \
-                            FunctionalState NewState)
-{
-    uint8_t tmp = 0;
-
-    CHECK_PARAM(PARAM_UART1_MODEM(UARTx));
-    CHECK_PARAM(PARAM_UART1_MODEM_MODE(Mode));
-    CHECK_PARAM(PARAM_FUNCTIONALSTATE(NewState));
-
-    switch(Mode){
-    case UART1_MODEM_MODE_LOOPBACK:
-        tmp = UART1_MCR_LOOPB_EN;
-        break;
-    case UART1_MODEM_MODE_AUTO_RTS:
-        tmp = UART1_MCR_AUTO_RTS_EN;
-        break;
-    case UART1_MODEM_MODE_AUTO_CTS:
-        tmp = UART1_MCR_AUTO_CTS_EN;
-        break;
-    default:
-        break;
-    }
-
-    if (NewState == ENABLE)
-    {
-        UARTx->MCR |= tmp;
-    }
-    else
-    {
-        UARTx->MCR &= (~tmp) & UART1_MCR_BITMASK;
-    }
-}
-
-
-/*********************************************************************//**
- * @brief        Get current status of modem status register
- * @param[in]    UARTx    LPC_UART1 (only)
- * @return         Current value of modem status register
- * Note:    The return value of this function must be ANDed with each member
- *             UART_MODEM_STAT_type enumeration to determine current flag status
- *             corresponding to each modem flag status. Because some flags in
- *             modem status register will be cleared after reading, the next reading
- *             modem register could not be correct. So this function used to
- *             read modem status register in one time only, then the return value
- *             used to check all flags.
- **********************************************************************/
-uint8_t UART_FullModemGetStatus(LPC_UART1_TypeDef *UARTx)
-{
-    CHECK_PARAM(PARAM_UART1_MODEM(UARTx));
-    return ((UARTx->MSR) & UART1_MSR_BITMASK);
-}
-
-
-/* UART RS485 functions --------------------------------------------------------------*/
-
-/*********************************************************************//**
- * @brief        Configure UART peripheral in RS485 mode according to the specified
-*               parameters in the RS485ConfigStruct.
- * @param[in]    UARTx    LPC_UART1 (only)
- * @param[in]    RS485ConfigStruct Pointer to a UART1_RS485_CTRLCFG_Type structure
-*                    that contains the configuration information for specified UART
-*                    in RS485 mode.
- * @return        None
- **********************************************************************/
-void UART_RS485Config(LPC_UART1_TypeDef *UARTx, UART1_RS485_CTRLCFG_Type *RS485ConfigStruct)
-{
-    uint32_t tmp;
-
-    CHECK_PARAM(PARAM_UART1_MODEM(UARTx));
-    CHECK_PARAM(PARAM_FUNCTIONALSTATE(RS485ConfigStruct->AutoAddrDetect_State));
-    CHECK_PARAM(PARAM_FUNCTIONALSTATE(RS485ConfigStruct->AutoDirCtrl_State));
-    CHECK_PARAM(PARAM_UART1_RS485_CFG_DELAYVALUE(RS485ConfigStruct->DelayValue));
-    CHECK_PARAM(PARAM_SETSTATE(RS485ConfigStruct->DirCtrlPol_Level));
-    CHECK_PARAM(PARAM_UART_RS485_DIRCTRL_PIN(RS485ConfigStruct->DirCtrlPin));
-    CHECK_PARAM(PARAM_UART1_RS485_CFG_MATCHADDRVALUE(RS485ConfigStruct->MatchAddrValue));
-    CHECK_PARAM(PARAM_FUNCTIONALSTATE(RS485ConfigStruct->NormalMultiDropMode_State));
-    CHECK_PARAM(PARAM_FUNCTIONALSTATE(RS485ConfigStruct->Rx_State));
-
-    tmp = 0;
-    // If Auto Direction Control is enabled -  This function is used in Master mode
-    if (RS485ConfigStruct->AutoDirCtrl_State == ENABLE)
-    {
-        tmp |= UART1_RS485CTRL_DCTRL_EN;
-
-        // Set polar
-        if (RS485ConfigStruct->DirCtrlPol_Level == SET)
-        {
-            tmp |= UART1_RS485CTRL_OINV_1;
-        }
-
-        // Set pin according to
-        if (RS485ConfigStruct->DirCtrlPin == UART1_RS485_DIRCTRL_DTR)
-        {
-            tmp |= UART1_RS485CTRL_SEL_DTR;
-        }
-
-        // Fill delay time
-        UARTx->RS485DLY = RS485ConfigStruct->DelayValue & UART1_RS485DLY_BITMASK;
-    }
-
-    // MultiDrop mode is enable
-    if (RS485ConfigStruct->NormalMultiDropMode_State == ENABLE)
-    {
-        tmp |= UART1_RS485CTRL_NMM_EN;
-    }
-
-    // Auto Address Detect function
-    if (RS485ConfigStruct->AutoAddrDetect_State == ENABLE)
-    {
-        tmp |= UART1_RS485CTRL_AADEN;
-        // Fill Match Address
-        UARTx->ADRMATCH = RS485ConfigStruct->MatchAddrValue & UART1_RS485ADRMATCH_BITMASK;
-    }
-
-
-    // Receiver is disable
-    if (RS485ConfigStruct->Rx_State == DISABLE)
-    {
-        tmp |= UART1_RS485CTRL_RX_DIS;
-    }
-
-    // write back to RS485 control register
-    UARTx->RS485CTRL = tmp & UART1_RS485CTRL_BITMASK;
-
-    // Enable Parity function and leave parity in stick '0' parity as default
-    UARTx->LCR |= (UART_LCR_PARITY_F_0 | UART_LCR_PARITY_EN);
-}
-
-/*********************************************************************//**
- * @brief        Enable/Disable receiver in RS485 module in UART1
- * @param[in]    UARTx    LPC_UART1 (only)
- * @param[in]    NewState    New State of command, should be:
- *                             - ENABLE: Enable this function.
- *                             - DISABLE: Disable this function.
- * @return        None
- **********************************************************************/
-void UART_RS485ReceiverCmd(LPC_UART1_TypeDef *UARTx, FunctionalState NewState)
-{
-    if (NewState == ENABLE){
-        UARTx->RS485CTRL &= ~UART1_RS485CTRL_RX_DIS;
-    } else {
-        UARTx->RS485CTRL |= UART1_RS485CTRL_RX_DIS;
-    }
-}
-
-/*********************************************************************//**
- * @brief        Send data on RS485 bus with specified parity stick value (9-bit mode).
- * @param[in]    UARTx    LPC_UART1 (only)
- * @param[in]    pDatFrm     Pointer to data frame.
- * @param[in]    size        Size of data.
- * @param[in]    ParityStick    Parity Stick value, should be 0 or 1.
- * @return        None
- **********************************************************************/
-uint32_t UART_RS485Send(LPC_UART1_TypeDef *UARTx, uint8_t *pDatFrm, \
-                    uint32_t size, uint8_t ParityStick)
-{
-    uint8_t tmp, save;
-    uint32_t cnt;
-
-    if (ParityStick){
-        save = tmp = UARTx->LCR & UART_LCR_BITMASK;
-        tmp &= ~(UART_LCR_PARITY_EVEN);
-        UARTx->LCR = tmp;
-        cnt = UART_Send((LPC_UART_TypeDef *)UARTx, pDatFrm, size, BLOCKING);
-        while (!(UARTx->LSR & UART_LSR_TEMT));
-        UARTx->LCR = save;
-    } else {
-        cnt = UART_Send((LPC_UART_TypeDef *)UARTx, pDatFrm, size, BLOCKING);
-        while (!(UARTx->LSR & UART_LSR_TEMT));
-    }
-    return cnt;
-}
-
-/*********************************************************************//**
- * @brief        Send Slave address frames on RS485 bus.
- * @param[in]    UARTx    LPC_UART1 (only)
- * @param[in]    SlvAddr Slave Address.
- * @return        None
- **********************************************************************/
-void UART_RS485SendSlvAddr(LPC_UART1_TypeDef *UARTx, uint8_t SlvAddr)
-{
-    UART_RS485Send(UARTx, &SlvAddr, 1, 1);
-}
-
-/*********************************************************************//**
- * @brief        Send Data frames on RS485 bus.
- * @param[in]    UARTx    LPC_UART1 (only)
- * @param[in]    pData Pointer to data to be sent.
- * @param[in]    size Size of data frame to be sent.
- * @return        None
- **********************************************************************/
-uint32_t UART_RS485SendData(LPC_UART1_TypeDef *UARTx, uint8_t *pData, uint32_t size)
-{
-    return (UART_RS485Send(UARTx, pData, size, 0));
-}
-
-#endif /* _UART1 */
-
-#endif /* _UART */
-
-/**
- * @}
- */
-
-/**
- * @}
- */
-/* --------------------------------- End Of File ------------------------------ */
-
+// /***********************************************************************//**
+//  * @file        lpc17xx_uart.c
+//  * @brief        Contains all functions support for UART firmware library on LPC17xx
+//  * @version        3.0
+//  * @date        18. June. 2010
+//  * @author        NXP MCU SW Application Team
+//  **************************************************************************
+//  * Software that is described herein is for illustrative purposes only
+//  * which provides customers with programming information regarding the
+//  * products. This software is supplied "AS IS" without any warranties.
+//  * NXP Semiconductors assumes no responsibility or liability for the
+//  * use of the software, conveys no license or title under any patent,
+//  * copyright, or mask work right to the product. NXP Semiconductors
+//  * reserves the right to make changes in the software without
+//  * notification. NXP Semiconductors also make no representation or
+//  * warranty that such application will be suitable for the specified
+//  * use without further testing or modification.
+//  **********************************************************************/
+//
+// /* Peripheral group ----------------------------------------------------------- */
+// /** @addtogroup UART
+//  * @{
+//  */
+//
+// /* Includes ------------------------------------------------------------------- */
+// #include "lpc17xx_uart.h"
+// #include "lpc17xx_clkpwr.h"
+//
+// /* If this source file built with example, the LPC17xx FW library configuration
+//  * file in each example directory ("lpc17xx_libcfg.h") must be included,
+//  * otherwise the default FW library configuration file must be included instead
+//  */
+// #ifdef __BUILD_WITH_EXAMPLE__
+// #include "lpc17xx_libcfg.h"
+// #else
+// #include "lpc17xx_libcfg_default.h"
+// #endif /* __BUILD_WITH_EXAMPLE__ */
+//
+//
+// #ifdef _UART
+//
+// /* Private Functions ---------------------------------------------------------- */
+//
+// static Status uart_set_divisors(LPC_UART_TypeDef *UARTx, uint32_t baudrate);
+//
+//
+// /*********************************************************************//**
+//  * @brief        Determines best dividers to get a target clock rate
+//  * @param[in]    UARTx    Pointer to selected UART peripheral, should be:
+//  *                 - LPC_UART0: UART0 peripheral
+//  *                 - LPC_UART1: UART1 peripheral
+//  *                 - LPC_UART2: UART2 peripheral
+//  *                 - LPC_UART3: UART3 peripheral
+//  * @param[in]    baudrate Desired UART baud rate.
+//  * @return         Error status, could be:
+//  *                 - SUCCESS
+//  *                 - ERROR
+//  **********************************************************************/
+// static Status uart_set_divisors(LPC_UART_TypeDef *UARTx, uint32_t baudrate)
+// {
+//     Status errorStatus = ERROR;
+//
+//     uint32_t uClk = 0;
+//     uint32_t calcBaudrate = 0;
+//     uint32_t temp = 0;
+//
+//     uint32_t mulFracDiv, dividerAddFracDiv;
+//     uint32_t diviser = 0 ;
+//     uint32_t mulFracDivOptimal = 1;
+//     uint32_t dividerAddOptimal = 0;
+//     uint32_t diviserOptimal = 0;
+//
+//     uint32_t relativeError = 0;
+//     uint32_t relativeOptimalError = 100000;
+//
+//     /* get UART block clock */
+//     if (UARTx == (LPC_UART_TypeDef *)LPC_UART0)
+//     {
+//         uClk = CLKPWR_GetPCLK (CLKPWR_PCLKSEL_UART0);
+//     }
+//     else if (UARTx == (LPC_UART_TypeDef *)LPC_UART1)
+//     {
+//         uClk = CLKPWR_GetPCLK (CLKPWR_PCLKSEL_UART1);
+//     }
+//     else if (UARTx == (LPC_UART_TypeDef *)LPC_UART2)
+//     {
+//         uClk = CLKPWR_GetPCLK (CLKPWR_PCLKSEL_UART2);
+//     }
+//     else if (UARTx == (LPC_UART_TypeDef *)LPC_UART3)
+//     {
+//         uClk = CLKPWR_GetPCLK (CLKPWR_PCLKSEL_UART3);
+//     }
+//
+//
+//     uClk = uClk >> 4; /* div by 16 */
+//     /* In the Uart IP block, baud rate is calculated using FDR and DLL-DLM registers
+//     * The formula is :
+//     * BaudRate= uClk * (mulFracDiv/(mulFracDiv+dividerAddFracDiv) / (16 * (DLL)
+//     * It involves floating point calculations. That's the reason the formulae are adjusted with
+//     * Multiply and divide method.*/
+//     /* The value of mulFracDiv and dividerAddFracDiv should comply to the following expressions:
+//     * 0 < mulFracDiv <= 15, 0 <= dividerAddFracDiv <= 15 */
+//     for (mulFracDiv = 1 ; mulFracDiv <= 15 ;mulFracDiv++)
+//     {
+//     for (dividerAddFracDiv = 0 ; dividerAddFracDiv <= 15 ;dividerAddFracDiv++)
+//     {
+//       temp = (mulFracDiv * uClk) / ((mulFracDiv + dividerAddFracDiv));
+//
+//       diviser = temp / baudrate;
+//       if ((temp % baudrate) > (baudrate / 2))
+//         diviser++;
+//
+//       if (diviser > 2 && diviser < 65536)
+//       {
+//         calcBaudrate = temp / diviser;
+//
+//         if (calcBaudrate <= baudrate)
+//           relativeError = baudrate - calcBaudrate;
+//         else
+//           relativeError = calcBaudrate - baudrate;
+//
+//         if ((relativeError < relativeOptimalError))
+//         {
+//           mulFracDivOptimal = mulFracDiv ;
+//           dividerAddOptimal = dividerAddFracDiv;
+//           diviserOptimal = diviser;
+//           relativeOptimalError = relativeError;
+//           if (relativeError == 0)
+//             break;
+//         }
+//       } /* End of if */
+//     } /* end of inner for loop */
+//     if (relativeError == 0)
+//       break;
+//     } /* end of outer for loop  */
+//
+//     if (relativeOptimalError < ((baudrate * UART_ACCEPTED_BAUDRATE_ERROR)/100))
+//     {
+//         if (((LPC_UART1_TypeDef *)UARTx) == LPC_UART1)
+//         {
+//             ((LPC_UART1_TypeDef *)UARTx)->LCR |= UART_LCR_DLAB_EN;
+//             ((LPC_UART1_TypeDef *)UARTx)->/*DLIER.*/DLM = UART_LOAD_DLM(diviserOptimal);
+//             ((LPC_UART1_TypeDef *)UARTx)->/*RBTHDLR.*/DLL = UART_LOAD_DLL(diviserOptimal);
+//             /* Then reset DLAB bit */
+//             ((LPC_UART1_TypeDef *)UARTx)->LCR &= (~UART_LCR_DLAB_EN) & UART_LCR_BITMASK;
+//             ((LPC_UART1_TypeDef *)UARTx)->FDR = (UART_FDR_MULVAL(mulFracDivOptimal) \
+//                     | UART_FDR_DIVADDVAL(dividerAddOptimal)) & UART_FDR_BITMASK;
+//         }
+//         else
+//         {
+//             UARTx->LCR |= UART_LCR_DLAB_EN;
+//             UARTx->/*DLIER.*/DLM = UART_LOAD_DLM(diviserOptimal);
+//             UARTx->/*RBTHDLR.*/DLL = UART_LOAD_DLL(diviserOptimal);
+//             /* Then reset DLAB bit */
+//             UARTx->LCR &= (~UART_LCR_DLAB_EN) & UART_LCR_BITMASK;
+//             UARTx->FDR = (UART_FDR_MULVAL(mulFracDivOptimal) \
+//                     | UART_FDR_DIVADDVAL(dividerAddOptimal)) & UART_FDR_BITMASK;
+//         }
+//         errorStatus = SUCCESS;
+//     }
+//
+//     return errorStatus;
+// }
+//
+// /* End of Private Functions ---------------------------------------------------- */
+//
+//
+// /* Public Functions ----------------------------------------------------------- */
+// /** @addtogroup UART_Public_Functions
+//  * @{
+//  */
+// /* UART Init/DeInit functions -------------------------------------------------*/
+// /********************************************************************//**
+//  * @brief        Initializes the UARTx peripheral according to the specified
+//  *               parameters in the UART_ConfigStruct.
+//  * @param[in]    UARTx    UART peripheral selected, should be:
+//  *               - LPC_UART0: UART0 peripheral
+//  *                 - LPC_UART1: UART1 peripheral
+//  *                 - LPC_UART2: UART2 peripheral
+//  *                 - LPC_UART3: UART3 peripheral
+//  * @param[in]    UART_ConfigStruct Pointer to a UART_CFG_Type structure
+// *                    that contains the configuration information for the
+// *                    specified UART peripheral.
+//  * @return         None
+//  *********************************************************************/
+// void UART_Init(LPC_UART_TypeDef *UARTx, UART_CFG_Type *UART_ConfigStruct)
+// {
+//     uint32_t tmp;
+//
+//     // For debug mode
+//     CHECK_PARAM(PARAM_UARTx(UARTx));
+//     CHECK_PARAM(PARAM_UART_DATABIT(UART_ConfigStruct->Databits));
+//     CHECK_PARAM(PARAM_UART_STOPBIT(UART_ConfigStruct->Stopbits));
+//     CHECK_PARAM(PARAM_UART_PARITY(UART_ConfigStruct->Parity));
+//
+// #ifdef _UART0
+//     if(UARTx == (LPC_UART_TypeDef *)LPC_UART0)
+//     {
+//         /* Set up clock and power for UART module */
+//         CLKPWR_ConfigPPWR (CLKPWR_PCONP_PCUART0, ENABLE);
+//     }
+// #endif
+//
+// #ifdef _UART1
+//     if(((LPC_UART1_TypeDef *)UARTx) == LPC_UART1)
+//     {
+//         /* Set up clock and power for UART module */
+//         CLKPWR_ConfigPPWR (CLKPWR_PCONP_PCUART1, ENABLE);
+//     }
+// #endif
+//
+// #ifdef _UART2
+//     if(UARTx == (LPC_UART_TypeDef *)LPC_UART2)
+//     {
+//         /* Set up clock and power for UART module */
+//         CLKPWR_ConfigPPWR (CLKPWR_PCONP_PCUART2, ENABLE);
+//     }
+// #endif
+//
+// #ifdef _UART3
+//     if(UARTx == (LPC_UART_TypeDef *)LPC_UART3)
+//     {
+//         /* Set up clock and power for UART module */
+//         CLKPWR_ConfigPPWR (CLKPWR_PCONP_PCUART3, ENABLE);
+//     }
+// #endif
+//
+//     if (((LPC_UART1_TypeDef *)UARTx) == LPC_UART1)
+//     {
+//         /* FIFOs are empty */
+//         ((LPC_UART1_TypeDef *)UARTx)->/*IIFCR.*/FCR = ( UART_FCR_FIFO_EN \
+//                 | UART_FCR_RX_RS | UART_FCR_TX_RS);
+//         // Disable FIFO
+//         ((LPC_UART1_TypeDef *)UARTx)->/*IIFCR.*/FCR = 0;
+//
+//         // Dummy reading
+//         while (((LPC_UART1_TypeDef *)UARTx)->LSR & UART_LSR_RDR)
+//         {
+//             tmp = ((LPC_UART1_TypeDef *)UARTx)->/*RBTHDLR.*/RBR;
+//         }
+//
+//         ((LPC_UART1_TypeDef *)UARTx)->TER = UART_TER_TXEN;
+//         // Wait for current transmit complete
+//         while (!(((LPC_UART1_TypeDef *)UARTx)->LSR & UART_LSR_THRE));
+//         // Disable Tx
+//         ((LPC_UART1_TypeDef *)UARTx)->TER = 0;
+//
+//         // Disable interrupt
+//         ((LPC_UART1_TypeDef *)UARTx)->/*DLIER.*/IER = 0;
+//         // Set LCR to default state
+//         ((LPC_UART1_TypeDef *)UARTx)->LCR = 0;
+//         // Set ACR to default state
+//         ((LPC_UART1_TypeDef *)UARTx)->ACR = 0;
+//         // Set Modem Control to default state
+//         ((LPC_UART1_TypeDef *)UARTx)->MCR = 0;
+//         // Set RS485 control to default state
+//         ((LPC_UART1_TypeDef *)UARTx)->RS485CTRL = 0;
+//         // Set RS485 delay timer to default state
+//         ((LPC_UART1_TypeDef *)UARTx)->RS485DLY = 0;
+//         // Set RS485 addr match to default state
+//         ((LPC_UART1_TypeDef *)UARTx)->ADRMATCH = 0;
+//         //Dummy Reading to Clear Status
+//         tmp = ((LPC_UART1_TypeDef *)UARTx)->MSR;
+//         tmp = ((LPC_UART1_TypeDef *)UARTx)->LSR;
+//     }
+//     else
+//     {
+//         /* FIFOs are empty */
+//         UARTx->/*IIFCR.*/FCR = ( UART_FCR_FIFO_EN | UART_FCR_RX_RS | UART_FCR_TX_RS);
+//         // Disable FIFO
+//         UARTx->/*IIFCR.*/FCR = 0;
+//
+//         // Dummy reading
+//         while (UARTx->LSR & UART_LSR_RDR)
+//         {
+//             tmp = UARTx->/*RBTHDLR.*/RBR;
+//         }
+//
+//         UARTx->TER = UART_TER_TXEN;
+//         // Wait for current transmit complete
+//         while (!(UARTx->LSR & UART_LSR_THRE));
+//         // Disable Tx
+//         UARTx->TER = 0;
+//
+//         // Disable interrupt
+//         UARTx->/*DLIER.*/IER = 0;
+//         // Set LCR to default state
+//         UARTx->LCR = 0;
+//         // Set ACR to default state
+//         UARTx->ACR = 0;
+//         // Dummy reading
+//         tmp = UARTx->LSR;
+//     }
+//
+//     if (UARTx == LPC_UART3)
+//     {
+//         // Set IrDA to default state
+//         UARTx->ICR = 0;
+//     }
+//
+//     // Set Line Control register ----------------------------
+//
+//     uart_set_divisors(UARTx, (UART_ConfigStruct->Baud_rate));
+//
+//     if (((LPC_UART1_TypeDef *)UARTx) == LPC_UART1)
+//     {
+//         tmp = (((LPC_UART1_TypeDef *)UARTx)->LCR & (UART_LCR_DLAB_EN | UART_LCR_BREAK_EN)) \
+//                 & UART_LCR_BITMASK;
+//     }
+//     else
+//     {
+//         tmp = (UARTx->LCR & (UART_LCR_DLAB_EN | UART_LCR_BREAK_EN)) & UART_LCR_BITMASK;
+//     }
+//
+//     switch (UART_ConfigStruct->Databits){
+//     case UART_DATABIT_5:
+//         tmp |= UART_LCR_WLEN5;
+//         break;
+//     case UART_DATABIT_6:
+//         tmp |= UART_LCR_WLEN6;
+//         break;
+//     case UART_DATABIT_7:
+//         tmp |= UART_LCR_WLEN7;
+//         break;
+//     case UART_DATABIT_8:
+//     default:
+//         tmp |= UART_LCR_WLEN8;
+//         break;
+//     }
+//
+//     if (UART_ConfigStruct->Parity == UART_PARITY_NONE)
+//     {
+//         // Do nothing...
+//     }
+//     else
+//     {
+//         tmp |= UART_LCR_PARITY_EN;
+//         switch (UART_ConfigStruct->Parity)
+//         {
+//         case UART_PARITY_ODD:
+//             tmp |= UART_LCR_PARITY_ODD;
+//             break;
+//
+//         case UART_PARITY_EVEN:
+//             tmp |= UART_LCR_PARITY_EVEN;
+//             break;
+//
+//         case UART_PARITY_SP_1:
+//             tmp |= UART_LCR_PARITY_F_1;
+//             break;
+//
+//         case UART_PARITY_SP_0:
+//             tmp |= UART_LCR_PARITY_F_0;
+//             break;
+//         default:
+//             break;
+//         }
+//     }
+//
+//     switch (UART_ConfigStruct->Stopbits){
+//     case UART_STOPBIT_2:
+//         tmp |= UART_LCR_STOPBIT_SEL;
+//         break;
+//     case UART_STOPBIT_1:
+//     default:
+//         // Do no thing
+//         break;
+//     }
+//
+//
+//     // Write back to LCR, configure FIFO and Disable Tx
+//     if (((LPC_UART1_TypeDef *)UARTx) ==  LPC_UART1)
+//     {
+//         ((LPC_UART1_TypeDef *)UARTx)->LCR = (uint8_t)(tmp & UART_LCR_BITMASK);
+//     }
+//     else
+//     {
+//         UARTx->LCR = (uint8_t)(tmp & UART_LCR_BITMASK);
+//     }
+// }
+//
+// /*********************************************************************//**
+//  * @brief        De-initializes the UARTx peripheral registers to their
+//  *                  default reset values.
+//  * @param[in]    UARTx    UART peripheral selected, should be:
+//  *               - LPC_UART0: UART0 peripheral
+//  *                 - LPC_UART1: UART1 peripheral
+//  *                 - LPC_UART2: UART2 peripheral
+//  *                 - LPC_UART3: UART3 peripheral
+//  * @return         None
+//  **********************************************************************/
+// void UART_DeInit(LPC_UART_TypeDef* UARTx)
+// {
+//     // For debug mode
+//     CHECK_PARAM(PARAM_UARTx(UARTx));
+//
+//     UART_TxCmd(UARTx, DISABLE);
+//
+// #ifdef _UART0
+//     if (UARTx == (LPC_UART_TypeDef *)LPC_UART0)
+//     {
+//         /* Set up clock and power for UART module */
+//         CLKPWR_ConfigPPWR (CLKPWR_PCONP_PCUART0, DISABLE);
+//     }
+// #endif
+//
+// #ifdef _UART1
+//     if (((LPC_UART1_TypeDef *)UARTx) == LPC_UART1)
+//     {
+//         /* Set up clock and power for UART module */
+//         CLKPWR_ConfigPPWR (CLKPWR_PCONP_PCUART1, DISABLE);
+//     }
+// #endif
+//
+// #ifdef _UART2
+//     if (UARTx == (LPC_UART_TypeDef *)LPC_UART2)
+//     {
+//         /* Set up clock and power for UART module */
+//         CLKPWR_ConfigPPWR (CLKPWR_PCONP_PCUART2, DISABLE);
+//     }
+// #endif
+//
+// #ifdef _UART3
+//     if (UARTx == (LPC_UART_TypeDef *)LPC_UART3)
+//     {
+//         /* Set up clock and power for UART module */
+//         CLKPWR_ConfigPPWR (CLKPWR_PCONP_PCUART3, DISABLE);
+//     }
+// #endif
+// }
+//
+// /*****************************************************************************//**
+// * @brief        Fills each UART_InitStruct member with its default value:
+// *                 - 9600 bps
+// *                 - 8-bit data
+// *                 - 1 Stopbit
+// *                 - None Parity
+// * @param[in]    UART_InitStruct Pointer to a UART_CFG_Type structure
+// *                    which will be initialized.
+// * @return        None
+// *******************************************************************************/
+// void UART_ConfigStructInit(UART_CFG_Type *UART_InitStruct)
+// {
+//     UART_InitStruct->Baud_rate = 9600;
+//     UART_InitStruct->Databits = UART_DATABIT_8;
+//     UART_InitStruct->Parity = UART_PARITY_NONE;
+//     UART_InitStruct->Stopbits = UART_STOPBIT_1;
+// }
+//
+// /* UART Send/Recieve functions -------------------------------------------------*/
+// /*********************************************************************//**
+//  * @brief        Transmit a single data through UART peripheral
+//  * @param[in]    UARTx    UART peripheral selected, should be:
+//  *               - LPC_UART0: UART0 peripheral
+//  *                 - LPC_UART1: UART1 peripheral
+//  *                 - LPC_UART2: UART2 peripheral
+//  *                 - LPC_UART3: UART3 peripheral
+//  * @param[in]    Data    Data to transmit (must be 8-bit long)
+//  * @return         None
+//  **********************************************************************/
+// void UART_SendByte(LPC_UART_TypeDef* UARTx, uint8_t Data)
+// {
+//     CHECK_PARAM(PARAM_UARTx(UARTx));
+//
+//     if (((LPC_UART1_TypeDef *)UARTx) == LPC_UART1)
+//     {
+//         ((LPC_UART1_TypeDef *)UARTx)->/*RBTHDLR.*/THR = Data & UART_THR_MASKBIT;
+//     }
+//     else
+//     {
+//         UARTx->/*RBTHDLR.*/THR = Data & UART_THR_MASKBIT;
+//     }
+//
+// }
+//
+//
+// /*********************************************************************//**
+//  * @brief        Receive a single data from UART peripheral
+//  * @param[in]    UARTx    UART peripheral selected, should be:
+//  *              - LPC_UART0: UART0 peripheral
+//  *                 - LPC_UART1: UART1 peripheral
+//  *                 - LPC_UART2: UART2 peripheral
+//  *                 - LPC_UART3: UART3 peripheral
+//  * @return         Data received
+//  **********************************************************************/
+// uint8_t UART_ReceiveByte(LPC_UART_TypeDef* UARTx)
+// {
+//     CHECK_PARAM(PARAM_UARTx(UARTx));
+//
+//     if (((LPC_UART1_TypeDef *)UARTx) == LPC_UART1)
+//     {
+//         return (((LPC_UART1_TypeDef *)UARTx)->/*RBTHDLR.*/RBR & UART_RBR_MASKBIT);
+//     }
+//     else
+//     {
+//         return (UARTx->/*RBTHDLR.*/RBR & UART_RBR_MASKBIT);
+//     }
+// }
+//
+// /*********************************************************************//**
+//  * @brief        Send a block of data via UART peripheral
+//  * @param[in]    UARTx    Selected UART peripheral used to send data, should be:
+//  *               - LPC_UART0: UART0 peripheral
+//  *                 - LPC_UART1: UART1 peripheral
+//  *                 - LPC_UART2: UART2 peripheral
+//  *                 - LPC_UART3: UART3 peripheral
+//  * @param[in]    txbuf     Pointer to Transmit buffer
+//  * @param[in]    buflen     Length of Transmit buffer
+//  * @param[in]     flag     Flag used in  UART transfer, should be
+//  *                         NONE_BLOCKING or BLOCKING
+//  * @return         Number of bytes sent.
+//  *
+//  * Note: when using UART in BLOCKING mode, a time-out condition is used
+//  * via defined symbol UART_BLOCKING_TIMEOUT.
+//  **********************************************************************/
+// uint32_t UART_Send(LPC_UART_TypeDef *UARTx, uint8_t *txbuf,
+//         uint32_t buflen, TRANSFER_BLOCK_Type flag)
+// {
+//     uint32_t bToSend, bSent, timeOut, fifo_cnt;
+//     uint8_t *pChar = txbuf;
+//
+//     bToSend = buflen;
+//
+//     // blocking mode
+//     if (flag == BLOCKING) {
+//         bSent = 0;
+//         while (bToSend){
+//             timeOut = UART_BLOCKING_TIMEOUT;
+//             // Wait for THR empty with timeout
+//             while (!(UARTx->LSR & UART_LSR_THRE)) {
+//                 if (timeOut == 0) break;
+//                 timeOut--;
+//             }
+//             // Time out!
+//             if(timeOut == 0) break;
+//             fifo_cnt = UART_TX_FIFO_SIZE;
+//             while (fifo_cnt && bToSend){
+//                 UART_SendByte(UARTx, (*pChar++));
+//                 fifo_cnt--;
+//                 bToSend--;
+//                 bSent++;
+//             }
+//         }
+//     }
+//     // None blocking mode
+//     else {
+//         bSent = 0;
+//         while (bToSend) {
+//             if (!(UARTx->LSR & UART_LSR_THRE)){
+//                 break;
+//             }
+//             fifo_cnt = UART_TX_FIFO_SIZE;
+//             while (fifo_cnt && bToSend) {
+//                 UART_SendByte(UARTx, (*pChar++));
+//                 bToSend--;
+//                 fifo_cnt--;
+//                 bSent++;
+//             }
+//         }
+//     }
+//     return bSent;
+// }
+//
+// /*********************************************************************//**
+//  * @brief        Receive a block of data via UART peripheral
+//  * @param[in]    UARTx    Selected UART peripheral used to send data,
+//  *                 should be:
+//  *               - LPC_UART0: UART0 peripheral
+//  *                 - LPC_UART1: UART1 peripheral
+//  *                 - LPC_UART2: UART2 peripheral
+//  *                 - LPC_UART3: UART3 peripheral
+//  * @param[out]    rxbuf     Pointer to Received buffer
+//  * @param[in]    buflen     Length of Received buffer
+//  * @param[in]     flag     Flag mode, should be NONE_BLOCKING or BLOCKING
+//
+//  * @return         Number of bytes received
+//  *
+//  * Note: when using UART in BLOCKING mode, a time-out condition is used
+//  * via defined symbol UART_BLOCKING_TIMEOUT.
+//  **********************************************************************/
+// uint32_t UART_Receive(LPC_UART_TypeDef *UARTx, uint8_t *rxbuf, \
+//         uint32_t buflen, TRANSFER_BLOCK_Type flag)
+// {
+//     uint32_t bToRecv, bRecv, timeOut;
+//     uint8_t *pChar = rxbuf;
+//
+//     bToRecv = buflen;
+//
+//     // Blocking mode
+//     if (flag == BLOCKING) {
+//         bRecv = 0;
+//         while (bToRecv){
+//             timeOut = UART_BLOCKING_TIMEOUT;
+//             while (!(UARTx->LSR & UART_LSR_RDR)){
+//                 if (timeOut == 0) break;
+//                 timeOut--;
+//             }
+//             // Time out!
+//             if(timeOut == 0) break;
+//             // Get data from the buffer
+//             (*pChar++) = UART_ReceiveByte(UARTx);
+//             bToRecv--;
+//             bRecv++;
+//         }
+//     }
+//     // None blocking mode
+//     else {
+//         bRecv = 0;
+//         while (bToRecv) {
+//             if (!(UARTx->LSR & UART_LSR_RDR)) {
+//                 break;
+//             } else {
+//                 (*pChar++) = UART_ReceiveByte(UARTx);
+//                 bRecv++;
+//                 bToRecv--;
+//             }
+//         }
+//     }
+//     return bRecv;
+// }
+//
+// /*********************************************************************//**
+//  * @brief        Force BREAK character on UART line, output pin UARTx TXD is
+//                 forced to logic 0.
+//  * @param[in]    UARTx    UART peripheral selected, should be:
+//  *              - LPC_UART0: UART0 peripheral
+//  *                 - LPC_UART1: UART1 peripheral
+//  *                 - LPC_UART2: UART2 peripheral
+//  *                 - LPC_UART3: UART3 peripheral
+//  * @return         None
+//  **********************************************************************/
+// void UART_ForceBreak(LPC_UART_TypeDef* UARTx)
+// {
+//     CHECK_PARAM(PARAM_UARTx(UARTx));
+//
+//     if (((LPC_UART1_TypeDef *)UARTx) == LPC_UART1)
+//     {
+//         ((LPC_UART1_TypeDef *)UARTx)->LCR |= UART_LCR_BREAK_EN;
+//     }
+//     else
+//     {
+//         UARTx->LCR |= UART_LCR_BREAK_EN;
+//     }
+// }
+//
+//
+// /********************************************************************//**
+//  * @brief         Enable or disable specified UART interrupt.
+//  * @param[in]    UARTx    UART peripheral selected, should be
+//  *              - LPC_UART0: UART0 peripheral
+//  *                 - LPC_UART1: UART1 peripheral
+//  *                 - LPC_UART2: UART2 peripheral
+//  *                 - LPC_UART3: UART3 peripheral
+//  * @param[in]    UARTIntCfg    Specifies the interrupt flag,
+//  *                 should be one of the following:
+//                 - UART_INTCFG_RBR     :  RBR Interrupt enable
+//                 - UART_INTCFG_THRE     :  THR Interrupt enable
+//                 - UART_INTCFG_RLS     :  RX line status interrupt enable
+//                 - UART1_INTCFG_MS    :  Modem status interrupt enable (UART1 only)
+//                 - UART1_INTCFG_CTS    :  CTS1 signal transition interrupt enable (UART1 only)
+//                 - UART_INTCFG_ABEO     :  Enables the end of auto-baud interrupt
+//                 - UART_INTCFG_ABTO     :  Enables the auto-baud time-out interrupt
+//  * @param[in]    NewState New state of specified UART interrupt type,
+//  *                 should be:
+//  *                 - ENALBE: Enable this UART interrupt type.
+// *                 - DISALBE: Disable this UART interrupt type.
+//  * @return         None
+//  *********************************************************************/
+// void UART_IntConfig(LPC_UART_TypeDef *UARTx, UART_INT_Type UARTIntCfg, FunctionalState NewState)
+// {
+//     uint32_t tmp = 0;
+//
+//     CHECK_PARAM(PARAM_UARTx(UARTx));
+//     CHECK_PARAM(PARAM_FUNCTIONALSTATE(NewState));
+//
+//     switch(UARTIntCfg){
+//         case UART_INTCFG_RBR:
+//             tmp = UART_IER_RBRINT_EN;
+//             break;
+//         case UART_INTCFG_THRE:
+//             tmp = UART_IER_THREINT_EN;
+//             break;
+//         case UART_INTCFG_RLS:
+//             tmp = UART_IER_RLSINT_EN;
+//             break;
+//         case UART1_INTCFG_MS:
+//             tmp = UART1_IER_MSINT_EN;
+//             break;
+//         case UART1_INTCFG_CTS:
+//             tmp = UART1_IER_CTSINT_EN;
+//             break;
+//         case UART_INTCFG_ABEO:
+//             tmp = UART_IER_ABEOINT_EN;
+//             break;
+//         case UART_INTCFG_ABTO:
+//             tmp = UART_IER_ABTOINT_EN;
+//             break;
+//     }
+//
+//     if ((LPC_UART1_TypeDef *) UARTx == LPC_UART1)
+//     {
+//         CHECK_PARAM((PARAM_UART_INTCFG(UARTIntCfg)) || (PARAM_UART1_INTCFG(UARTIntCfg)));
+//     }
+//     else
+//     {
+//         CHECK_PARAM(PARAM_UART_INTCFG(UARTIntCfg));
+//     }
+//
+//     if (NewState == ENABLE)
+//     {
+//         if ((LPC_UART1_TypeDef *) UARTx == LPC_UART1)
+//         {
+//             ((LPC_UART1_TypeDef *)UARTx)->/*DLIER.*/IER |= tmp;
+//         }
+//         else
+//         {
+//             UARTx->/*DLIER.*/IER |= tmp;
+//         }
+//     }
+//     else
+//     {
+//         if ((LPC_UART1_TypeDef *) UARTx == LPC_UART1)
+//         {
+//             ((LPC_UART1_TypeDef *)UARTx)->/*DLIER.*/IER &= (~tmp) & UART1_IER_BITMASK;
+//         }
+//         else
+//         {
+//             UARTx->/*DLIER.*/IER &= (~tmp) & UART_IER_BITMASK;
+//         }
+//     }
+// }
+//
+//
+// /********************************************************************//**
+//  * @brief         Get current value of Line Status register in UART peripheral.
+//  * @param[in]    UARTx    UART peripheral selected, should be:
+//  *              - LPC_UART0: UART0 peripheral
+//  *                 - LPC_UART1: UART1 peripheral
+//  *                 - LPC_UART2: UART2 peripheral
+//  *                 - LPC_UART3: UART3 peripheral
+//  * @return        Current value of Line Status register in UART peripheral.
+//  * Note:    The return value of this function must be ANDed with each member in
+//  *             UART_LS_Type enumeration to determine current flag status
+//  *             corresponding to each Line status type. Because some flags in
+//  *             Line Status register will be cleared after reading, the next reading
+//  *             Line Status register could not be correct. So this function used to
+//  *             read Line status register in one time only, then the return value
+//  *             used to check all flags.
+//  *********************************************************************/
+// uint8_t UART_GetLineStatus(LPC_UART_TypeDef* UARTx)
+// {
+//     CHECK_PARAM(PARAM_UARTx(UARTx));
+//
+//     if (((LPC_UART1_TypeDef *)UARTx) == LPC_UART1)
+//     {
+//         return ((((LPC_UART1_TypeDef *)LPC_UART1)->LSR) & UART_LSR_BITMASK);
+//     }
+//     else
+//     {
+//         return ((UARTx->LSR) & UART_LSR_BITMASK);
+//     }
+// }
+//
+// /********************************************************************//**
+//  * @brief         Get Interrupt Identification value
+//  * @param[in]    UARTx    UART peripheral selected, should be:
+//  *              - LPC_UART0: UART0 peripheral
+//  *                 - LPC_UART1: UART1 peripheral
+//  *                 - LPC_UART2: UART2 peripheral
+//  *                 - LPC_UART3: UART3 peripheral
+//  * @return        Current value of UART UIIR register in UART peripheral.
+//  *********************************************************************/
+// uint32_t UART_GetIntId(LPC_UART_TypeDef* UARTx)
+// {
+//     CHECK_PARAM(PARAM_UARTx(UARTx));
+//     return (UARTx->IIR & 0x03CF);
+// }
+//
+// /*********************************************************************//**
+//  * @brief        Check whether if UART is busy or not
+//  * @param[in]    UARTx    UART peripheral selected, should be:
+//  *              - LPC_UART0: UART0 peripheral
+//  *                 - LPC_UART1: UART1 peripheral
+//  *                 - LPC_UART2: UART2 peripheral
+//  *                 - LPC_UART3: UART3 peripheral
+//  * @return        RESET if UART is not busy, otherwise return SET.
+//  **********************************************************************/
+// FlagStatus UART_CheckBusy(LPC_UART_TypeDef *UARTx)
+// {
+//     if (UARTx->LSR & UART_LSR_TEMT){
+//         return RESET;
+//     } else {
+//         return SET;
+//     }
+// }
+//
+//
+// /*********************************************************************//**
+//  * @brief        Configure FIFO function on selected UART peripheral
+//  * @param[in]    UARTx    UART peripheral selected, should be:
+//  *              - LPC_UART0: UART0 peripheral
+//  *                 - LPC_UART1: UART1 peripheral
+//  *                 - LPC_UART2: UART2 peripheral
+//  *                 - LPC_UART3: UART3 peripheral
+//  * @param[in]    FIFOCfg    Pointer to a UART_FIFO_CFG_Type Structure that
+//  *                         contains specified information about FIFO configuration
+//  * @return         none
+//  **********************************************************************/
+// void UART_FIFOConfig(LPC_UART_TypeDef *UARTx, UART_FIFO_CFG_Type *FIFOCfg)
+// {
+//     uint8_t tmp = 0;
+//
+//     CHECK_PARAM(PARAM_UARTx(UARTx));
+//     CHECK_PARAM(PARAM_UART_FIFO_LEVEL(FIFOCfg->FIFO_Level));
+//     CHECK_PARAM(PARAM_FUNCTIONALSTATE(FIFOCfg->FIFO_DMAMode));
+//     CHECK_PARAM(PARAM_FUNCTIONALSTATE(FIFOCfg->FIFO_ResetRxBuf));
+//     CHECK_PARAM(PARAM_FUNCTIONALSTATE(FIFOCfg->FIFO_ResetTxBuf));
+//
+//     tmp |= UART_FCR_FIFO_EN;
+//     switch (FIFOCfg->FIFO_Level){
+//     case UART_FIFO_TRGLEV0:
+//         tmp |= UART_FCR_TRG_LEV0;
+//         break;
+//     case UART_FIFO_TRGLEV1:
+//         tmp |= UART_FCR_TRG_LEV1;
+//         break;
+//     case UART_FIFO_TRGLEV2:
+//         tmp |= UART_FCR_TRG_LEV2;
+//         break;
+//     case UART_FIFO_TRGLEV3:
+//     default:
+//         tmp |= UART_FCR_TRG_LEV3;
+//         break;
+//     }
+//
+//     if (FIFOCfg->FIFO_ResetTxBuf == ENABLE)
+//     {
+//         tmp |= UART_FCR_TX_RS;
+//     }
+//     if (FIFOCfg->FIFO_ResetRxBuf == ENABLE)
+//     {
+//         tmp |= UART_FCR_RX_RS;
+//     }
+//     if (FIFOCfg->FIFO_DMAMode == ENABLE)
+//     {
+//         tmp |= UART_FCR_DMAMODE_SEL;
+//     }
+//
+//
+//     //write to FIFO control register
+//     if (((LPC_UART1_TypeDef *)UARTx) == LPC_UART1)
+//     {
+//         ((LPC_UART1_TypeDef *)UARTx)->/*IIFCR.*/FCR = tmp & UART_FCR_BITMASK;
+//     }
+//     else
+//     {
+//         UARTx->/*IIFCR.*/FCR = tmp & UART_FCR_BITMASK;
+//     }
+// }
+//
+// /*****************************************************************************//**
+// * @brief        Fills each UART_FIFOInitStruct member with its default value:
+// *                 - FIFO_DMAMode = DISABLE
+// *                 - FIFO_Level = UART_FIFO_TRGLEV0
+// *                 - FIFO_ResetRxBuf = ENABLE
+// *                 - FIFO_ResetTxBuf = ENABLE
+// *                 - FIFO_State = ENABLE
+//
+// * @param[in]    UART_FIFOInitStruct Pointer to a UART_FIFO_CFG_Type structure
+// *                    which will be initialized.
+// * @return        None
+// *******************************************************************************/
+// void UART_FIFOConfigStructInit(UART_FIFO_CFG_Type *UART_FIFOInitStruct)
+// {
+//     UART_FIFOInitStruct->FIFO_DMAMode = DISABLE;
+//     UART_FIFOInitStruct->FIFO_Level = UART_FIFO_TRGLEV0;
+//     UART_FIFOInitStruct->FIFO_ResetRxBuf = ENABLE;
+//     UART_FIFOInitStruct->FIFO_ResetTxBuf = ENABLE;
+// }
+//
+//
+// /*********************************************************************//**
+//  * @brief        Start/Stop Auto Baudrate activity
+//  * @param[in]    UARTx    UART peripheral selected, should be
+//  *               - LPC_UART0: UART0 peripheral
+//  *                 - LPC_UART1: UART1 peripheral
+//  *                 - LPC_UART2: UART2 peripheral
+//  *                 - LPC_UART3: UART3 peripheral
+//  * @param[in]    ABConfigStruct    A pointer to UART_AB_CFG_Type structure that
+//  *                                 contains specified information about UART
+//  *                                 auto baudrate configuration
+//  * @param[in]    NewState New State of Auto baudrate activity, should be:
+//  *                 - ENABLE: Start this activity
+//  *                - DISABLE: Stop this activity
+//  * Note:        Auto-baudrate mode enable bit will be cleared once this mode
+//  *                 completed.
+//  * @return         none
+//  **********************************************************************/
+// void UART_ABCmd(LPC_UART_TypeDef *UARTx, UART_AB_CFG_Type *ABConfigStruct, \
+//                 FunctionalState NewState)
+// {
+//     uint32_t tmp;
+//
+//     CHECK_PARAM(PARAM_UARTx(UARTx));
+//     CHECK_PARAM(PARAM_FUNCTIONALSTATE(NewState));
+//
+//     tmp = 0;
+//     if (NewState == ENABLE) {
+//         if (ABConfigStruct->ABMode == UART_AUTOBAUD_MODE1){
+//             tmp |= UART_ACR_MODE;
+//         }
+//         if (ABConfigStruct->AutoRestart == ENABLE){
+//             tmp |= UART_ACR_AUTO_RESTART;
+//         }
+//     }
+//
+//     if (((LPC_UART1_TypeDef *)UARTx) == LPC_UART1)
+//     {
+//         if (NewState == ENABLE)
+//         {
+//             // Clear DLL and DLM value
+//             ((LPC_UART1_TypeDef *)UARTx)->LCR |= UART_LCR_DLAB_EN;
+//             ((LPC_UART1_TypeDef *)UARTx)->DLL = 0;
+//             ((LPC_UART1_TypeDef *)UARTx)->DLM = 0;
+//             ((LPC_UART1_TypeDef *)UARTx)->LCR &= ~UART_LCR_DLAB_EN;
+//             // FDR value must be reset to default value
+//             ((LPC_UART1_TypeDef *)UARTx)->FDR = 0x10;
+//             ((LPC_UART1_TypeDef *)UARTx)->ACR = UART_ACR_START | tmp;
+//         }
+//         else
+//         {
+//             ((LPC_UART1_TypeDef *)UARTx)->ACR = 0;
+//         }
+//     }
+//     else
+//     {
+//         if (NewState == ENABLE)
+//         {
+//             // Clear DLL and DLM value
+//             UARTx->LCR |= UART_LCR_DLAB_EN;
+//             UARTx->DLL = 0;
+//             UARTx->DLM = 0;
+//             UARTx->LCR &= ~UART_LCR_DLAB_EN;
+//             // FDR value must be reset to default value
+//             UARTx->FDR = 0x10;
+//             UARTx->ACR = UART_ACR_START | tmp;
+//         }
+//         else
+//         {
+//             UARTx->ACR = 0;
+//         }
+//     }
+// }
+//
+// /*********************************************************************//**
+//  * @brief        Clear Autobaud Interrupt Pending
+//  * @param[in]    UARTx    UART peripheral selected, should be
+//  *               - LPC_UART0: UART0 peripheral
+//  *                 - LPC_UART1: UART1 peripheral
+//  *                 - LPC_UART2: UART2 peripheral
+//  *                 - LPC_UART3: UART3 peripheral
+//  * @param[in]    ABIntType    type of auto-baud interrupt, should be:
+//  *                 - UART_AUTOBAUD_INTSTAT_ABEO: End of Auto-baud interrupt
+//  *                 - UART_AUTOBAUD_INTSTAT_ABTO: Auto-baud time out interrupt
+//  * @return         none
+//  **********************************************************************/
+// void UART_ABClearIntPending(LPC_UART_TypeDef *UARTx, UART_ABEO_Type ABIntType)
+// {
+//     CHECK_PARAM(PARAM_UARTx(UARTx));
+//     if (((LPC_UART1_TypeDef *)UARTx) == LPC_UART1)
+//     {
+//         UARTx->ACR |= ABIntType;
+//     }
+//     else
+//         UARTx->ACR |= ABIntType;
+// }
+//
+// /*********************************************************************//**
+//  * @brief        Enable/Disable transmission on UART TxD pin
+//  * @param[in]    UARTx    UART peripheral selected, should be:
+//  *               - LPC_UART0: UART0 peripheral
+//  *                 - LPC_UART1: UART1 peripheral
+//  *                 - LPC_UART2: UART2 peripheral
+//  *                 - LPC_UART3: UART3 peripheral
+//  * @param[in]    NewState New State of Tx transmission function, should be:
+//  *                 - ENABLE: Enable this function
+//                 - DISABLE: Disable this function
+//  * @return none
+//  **********************************************************************/
+// void UART_TxCmd(LPC_UART_TypeDef *UARTx, FunctionalState NewState)
+// {
+//     CHECK_PARAM(PARAM_UARTx(UARTx));
+//     CHECK_PARAM(PARAM_FUNCTIONALSTATE(NewState));
+//
+//     if (NewState == ENABLE)
+//     {
+//         if (((LPC_UART1_TypeDef *)UARTx) == LPC_UART1)
+//         {
+//             ((LPC_UART1_TypeDef *)UARTx)->TER |= UART_TER_TXEN;
+//         }
+//         else
+//         {
+//             UARTx->TER |= UART_TER_TXEN;
+//         }
+//     }
+//     else
+//     {
+//         if (((LPC_UART1_TypeDef *)UARTx) == LPC_UART1)
+//         {
+//             ((LPC_UART1_TypeDef *)UARTx)->TER &= (~UART_TER_TXEN) & UART_TER_BITMASK;
+//         }
+//         else
+//         {
+//             UARTx->TER &= (~UART_TER_TXEN) & UART_TER_BITMASK;
+//         }
+//     }
+// }
+//
+// /* UART IrDA functions ---------------------------------------------------*/
+//
+// #ifdef _UART3
+//
+// /*********************************************************************//**
+//  * @brief        Enable or disable inverting serial input function of IrDA
+//  *                 on UART peripheral.
+//  * @param[in]    UARTx UART peripheral selected, should be LPC_UART3 (only)
+//  * @param[in]    NewState New state of inverting serial input, should be:
+//  *                 - ENABLE: Enable this function.
+//  *                 - DISABLE: Disable this function.
+//  * @return none
+//  **********************************************************************/
+// void UART_IrDAInvtInputCmd(LPC_UART_TypeDef* UARTx, FunctionalState NewState)
+// {
+//     CHECK_PARAM(PARAM_UART_IrDA(UARTx));
+//     CHECK_PARAM(PARAM_FUNCTIONALSTATE(NewState));
+//
+//     if (NewState == ENABLE)
+//     {
+//         UARTx->ICR |= UART_ICR_IRDAINV;
+//     }
+//     else if (NewState == DISABLE)
+//     {
+//         UARTx->ICR &= (~UART_ICR_IRDAINV) & UART_ICR_BITMASK;
+//     }
+// }
+//
+//
+// /*********************************************************************//**
+//  * @brief        Enable or disable IrDA function on UART peripheral.
+//  * @param[in]    UARTx UART peripheral selected, should be LPC_UART3 (only)
+//  * @param[in]    NewState New state of IrDA function, should be:
+//  *                 - ENABLE: Enable this function.
+//  *                 - DISABLE: Disable this function.
+//  * @return none
+//  **********************************************************************/
+// void UART_IrDACmd(LPC_UART_TypeDef* UARTx, FunctionalState NewState)
+// {
+//     CHECK_PARAM(PARAM_UART_IrDA(UARTx));
+//     CHECK_PARAM(PARAM_FUNCTIONALSTATE(NewState));
+//
+//     if (NewState == ENABLE)
+//     {
+//         UARTx->ICR |= UART_ICR_IRDAEN;
+//     }
+//     else
+//     {
+//         UARTx->ICR &= (~UART_ICR_IRDAEN) & UART_ICR_BITMASK;
+//     }
+// }
+//
+//
+// /*********************************************************************//**
+//  * @brief        Configure Pulse divider for IrDA function on UART peripheral.
+//  * @param[in]    UARTx UART peripheral selected, should be LPC_UART3 (only)
+//  * @param[in]    PulseDiv Pulse Divider value from Peripheral clock,
+//  *                 should be one of the following:
+//                 - UART_IrDA_PULSEDIV2     : Pulse width = 2 * Tpclk
+//                 - UART_IrDA_PULSEDIV4     : Pulse width = 4 * Tpclk
+//                 - UART_IrDA_PULSEDIV8     : Pulse width = 8 * Tpclk
+//                 - UART_IrDA_PULSEDIV16     : Pulse width = 16 * Tpclk
+//                 - UART_IrDA_PULSEDIV32     : Pulse width = 32 * Tpclk
+//                 - UART_IrDA_PULSEDIV64     : Pulse width = 64 * Tpclk
+//                 - UART_IrDA_PULSEDIV128 : Pulse width = 128 * Tpclk
+//                 - UART_IrDA_PULSEDIV256 : Pulse width = 256 * Tpclk
+//
+//  * @return none
+//  **********************************************************************/
+// void UART_IrDAPulseDivConfig(LPC_UART_TypeDef *UARTx, UART_IrDA_PULSE_Type PulseDiv)
+// {
+//     uint32_t tmp, tmp1;
+//     CHECK_PARAM(PARAM_UART_IrDA(UARTx));
+//     CHECK_PARAM(PARAM_UART_IrDA_PULSEDIV(PulseDiv));
+//
+//     tmp1 = UART_ICR_PULSEDIV(PulseDiv);
+//     tmp = UARTx->ICR & (~UART_ICR_PULSEDIV(7));
+//     tmp |= tmp1 | UART_ICR_FIXPULSE_EN;
+//     UARTx->ICR = tmp & UART_ICR_BITMASK;
+// }
+//
+// #endif
+//
+//
+// /* UART1 FullModem function ---------------------------------------------*/
+//
+// #ifdef _UART1
+//
+// /*********************************************************************//**
+//  * @brief        Force pin DTR/RTS corresponding to given state (Full modem mode)
+//  * @param[in]    UARTx    LPC_UART1 (only)
+//  * @param[in]    Pin    Pin that NewState will be applied to, should be:
+//  *                 - UART1_MODEM_PIN_DTR: DTR pin.
+//  *                 - UART1_MODEM_PIN_RTS: RTS pin.
+//  * @param[in]    NewState New State of DTR/RTS pin, should be:
+//  *                 - INACTIVE: Force the pin to inactive signal.
+//                 - ACTIVE: Force the pin to active signal.
+//  * @return none
+//  **********************************************************************/
+// void UART_FullModemForcePinState(LPC_UART1_TypeDef *UARTx, UART_MODEM_PIN_Type Pin, \
+//                             UART1_SignalState NewState)
+// {
+//     uint8_t tmp = 0;
+//
+//     CHECK_PARAM(PARAM_UART1_MODEM(UARTx));
+//     CHECK_PARAM(PARAM_UART1_MODEM_PIN(Pin));
+//     CHECK_PARAM(PARAM_UART1_SIGNALSTATE(NewState));
+//
+//     switch (Pin){
+//     case UART1_MODEM_PIN_DTR:
+//         tmp = UART1_MCR_DTR_CTRL;
+//         break;
+//     case UART1_MODEM_PIN_RTS:
+//         tmp = UART1_MCR_RTS_CTRL;
+//         break;
+//     default:
+//         break;
+//     }
+//
+//     if (NewState == ACTIVE){
+//         UARTx->MCR |= tmp;
+//     } else {
+//         UARTx->MCR &= (~tmp) & UART1_MCR_BITMASK;
+//     }
+// }
+//
+//
+// /*********************************************************************//**
+//  * @brief        Configure Full Modem mode for UART peripheral
+//  * @param[in]    UARTx    LPC_UART1 (only)
+//  * @param[in]    Mode Full Modem mode, should be:
+//  *                 - UART1_MODEM_MODE_LOOPBACK: Loop back mode.
+//  *                 - UART1_MODEM_MODE_AUTO_RTS: Auto-RTS mode.
+//  *                 - UART1_MODEM_MODE_AUTO_CTS: Auto-CTS mode.
+//  * @param[in]    NewState New State of this mode, should be:
+//  *                 - ENABLE: Enable this mode.
+//                 - DISABLE: Disable this mode.
+//  * @return none
+//  **********************************************************************/
+// void UART_FullModemConfigMode(LPC_UART1_TypeDef *UARTx, UART_MODEM_MODE_Type Mode, \
+//                             FunctionalState NewState)
+// {
+//     uint8_t tmp = 0;
+//
+//     CHECK_PARAM(PARAM_UART1_MODEM(UARTx));
+//     CHECK_PARAM(PARAM_UART1_MODEM_MODE(Mode));
+//     CHECK_PARAM(PARAM_FUNCTIONALSTATE(NewState));
+//
+//     switch(Mode){
+//     case UART1_MODEM_MODE_LOOPBACK:
+//         tmp = UART1_MCR_LOOPB_EN;
+//         break;
+//     case UART1_MODEM_MODE_AUTO_RTS:
+//         tmp = UART1_MCR_AUTO_RTS_EN;
+//         break;
+//     case UART1_MODEM_MODE_AUTO_CTS:
+//         tmp = UART1_MCR_AUTO_CTS_EN;
+//         break;
+//     default:
+//         break;
+//     }
+//
+//     if (NewState == ENABLE)
+//     {
+//         UARTx->MCR |= tmp;
+//     }
+//     else
+//     {
+//         UARTx->MCR &= (~tmp) & UART1_MCR_BITMASK;
+//     }
+// }
+//
+//
+// /*********************************************************************//**
+//  * @brief        Get current status of modem status register
+//  * @param[in]    UARTx    LPC_UART1 (only)
+//  * @return         Current value of modem status register
+//  * Note:    The return value of this function must be ANDed with each member
+//  *             UART_MODEM_STAT_type enumeration to determine current flag status
+//  *             corresponding to each modem flag status. Because some flags in
+//  *             modem status register will be cleared after reading, the next reading
+//  *             modem register could not be correct. So this function used to
+//  *             read modem status register in one time only, then the return value
+//  *             used to check all flags.
+//  **********************************************************************/
+// uint8_t UART_FullModemGetStatus(LPC_UART1_TypeDef *UARTx)
+// {
+//     CHECK_PARAM(PARAM_UART1_MODEM(UARTx));
+//     return ((UARTx->MSR) & UART1_MSR_BITMASK);
+// }
+//
+//
+// /* UART RS485 functions --------------------------------------------------------------*/
+//
+// /*********************************************************************//**
+//  * @brief        Configure UART peripheral in RS485 mode according to the specified
+// *               parameters in the RS485ConfigStruct.
+//  * @param[in]    UARTx    LPC_UART1 (only)
+//  * @param[in]    RS485ConfigStruct Pointer to a UART1_RS485_CTRLCFG_Type structure
+// *                    that contains the configuration information for specified UART
+// *                    in RS485 mode.
+//  * @return        None
+//  **********************************************************************/
+// void UART_RS485Config(LPC_UART1_TypeDef *UARTx, UART1_RS485_CTRLCFG_Type *RS485ConfigStruct)
+// {
+//     uint32_t tmp;
+//
+//     CHECK_PARAM(PARAM_UART1_MODEM(UARTx));
+//     CHECK_PARAM(PARAM_FUNCTIONALSTATE(RS485ConfigStruct->AutoAddrDetect_State));
+//     CHECK_PARAM(PARAM_FUNCTIONALSTATE(RS485ConfigStruct->AutoDirCtrl_State));
+//     CHECK_PARAM(PARAM_UART1_RS485_CFG_DELAYVALUE(RS485ConfigStruct->DelayValue));
+//     CHECK_PARAM(PARAM_SETSTATE(RS485ConfigStruct->DirCtrlPol_Level));
+//     CHECK_PARAM(PARAM_UART_RS485_DIRCTRL_PIN(RS485ConfigStruct->DirCtrlPin));
+//     CHECK_PARAM(PARAM_UART1_RS485_CFG_MATCHADDRVALUE(RS485ConfigStruct->MatchAddrValue));
+//     CHECK_PARAM(PARAM_FUNCTIONALSTATE(RS485ConfigStruct->NormalMultiDropMode_State));
+//     CHECK_PARAM(PARAM_FUNCTIONALSTATE(RS485ConfigStruct->Rx_State));
+//
+//     tmp = 0;
+//     // If Auto Direction Control is enabled -  This function is used in Master mode
+//     if (RS485ConfigStruct->AutoDirCtrl_State == ENABLE)
+//     {
+//         tmp |= UART1_RS485CTRL_DCTRL_EN;
+//
+//         // Set polar
+//         if (RS485ConfigStruct->DirCtrlPol_Level == SET)
+//         {
+//             tmp |= UART1_RS485CTRL_OINV_1;
+//         }
+//
+//         // Set pin according to
+//         if (RS485ConfigStruct->DirCtrlPin == UART1_RS485_DIRCTRL_DTR)
+//         {
+//             tmp |= UART1_RS485CTRL_SEL_DTR;
+//         }
+//
+//         // Fill delay time
+//         UARTx->RS485DLY = RS485ConfigStruct->DelayValue & UART1_RS485DLY_BITMASK;
+//     }
+//
+//     // MultiDrop mode is enable
+//     if (RS485ConfigStruct->NormalMultiDropMode_State == ENABLE)
+//     {
+//         tmp |= UART1_RS485CTRL_NMM_EN;
+//     }
+//
+//     // Auto Address Detect function
+//     if (RS485ConfigStruct->AutoAddrDetect_State == ENABLE)
+//     {
+//         tmp |= UART1_RS485CTRL_AADEN;
+//         // Fill Match Address
+//         UARTx->ADRMATCH = RS485ConfigStruct->MatchAddrValue & UART1_RS485ADRMATCH_BITMASK;
+//     }
+//
+//
+//     // Receiver is disable
+//     if (RS485ConfigStruct->Rx_State == DISABLE)
+//     {
+//         tmp |= UART1_RS485CTRL_RX_DIS;
+//     }
+//
+//     // write back to RS485 control register
+//     UARTx->RS485CTRL = tmp & UART1_RS485CTRL_BITMASK;
+//
+//     // Enable Parity function and leave parity in stick '0' parity as default
+//     UARTx->LCR |= (UART_LCR_PARITY_F_0 | UART_LCR_PARITY_EN);
+// }
+//
+// /*********************************************************************//**
+//  * @brief        Enable/Disable receiver in RS485 module in UART1
+//  * @param[in]    UARTx    LPC_UART1 (only)
+//  * @param[in]    NewState    New State of command, should be:
+//  *                             - ENABLE: Enable this function.
+//  *                             - DISABLE: Disable this function.
+//  * @return        None
+//  **********************************************************************/
+// void UART_RS485ReceiverCmd(LPC_UART1_TypeDef *UARTx, FunctionalState NewState)
+// {
+//     if (NewState == ENABLE){
+//         UARTx->RS485CTRL &= ~UART1_RS485CTRL_RX_DIS;
+//     } else {
+//         UARTx->RS485CTRL |= UART1_RS485CTRL_RX_DIS;
+//     }
+// }
+//
+// /*********************************************************************//**
+//  * @brief        Send data on RS485 bus with specified parity stick value (9-bit mode).
+//  * @param[in]    UARTx    LPC_UART1 (only)
+//  * @param[in]    pDatFrm     Pointer to data frame.
+//  * @param[in]    size        Size of data.
+//  * @param[in]    ParityStick    Parity Stick value, should be 0 or 1.
+//  * @return        None
+//  **********************************************************************/
+// uint32_t UART_RS485Send(LPC_UART1_TypeDef *UARTx, uint8_t *pDatFrm, \
+//                     uint32_t size, uint8_t ParityStick)
+// {
+//     uint8_t tmp, save;
+//     uint32_t cnt;
+//
+//     if (ParityStick){
+//         save = tmp = UARTx->LCR & UART_LCR_BITMASK;
+//         tmp &= ~(UART_LCR_PARITY_EVEN);
+//         UARTx->LCR = tmp;
+//         cnt = UART_Send((LPC_UART_TypeDef *)UARTx, pDatFrm, size, BLOCKING);
+//         while (!(UARTx->LSR & UART_LSR_TEMT));
+//         UARTx->LCR = save;
+//     } else {
+//         cnt = UART_Send((LPC_UART_TypeDef *)UARTx, pDatFrm, size, BLOCKING);
+//         while (!(UARTx->LSR & UART_LSR_TEMT));
+//     }
+//     return cnt;
+// }
+//
+// /*********************************************************************//**
+//  * @brief        Send Slave address frames on RS485 bus.
+//  * @param[in]    UARTx    LPC_UART1 (only)
+//  * @param[in]    SlvAddr Slave Address.
+//  * @return        None
+//  **********************************************************************/
+// void UART_RS485SendSlvAddr(LPC_UART1_TypeDef *UARTx, uint8_t SlvAddr)
+// {
+//     UART_RS485Send(UARTx, &SlvAddr, 1, 1);
+// }
+//
+// /*********************************************************************//**
+//  * @brief        Send Data frames on RS485 bus.
+//  * @param[in]    UARTx    LPC_UART1 (only)
+//  * @param[in]    pData Pointer to data to be sent.
+//  * @param[in]    size Size of data frame to be sent.
+//  * @return        None
+//  **********************************************************************/
+// uint32_t UART_RS485SendData(LPC_UART1_TypeDef *UARTx, uint8_t *pData, uint32_t size)
+// {
+//     return (UART_RS485Send(UARTx, pData, size, 0));
+// }
+//
+// #endif /* _UART1 */
+//
+// #endif /* _UART */
+//
+// /**
+//  * @}
+//  */
+//
+// /**
+//  * @}
+//  */
+// /* --------------------------------- End Of File ------------------------------ */
+//

--- a/CMSISv2p00_LPC17xx/Drivers/src/lpc17xx_uartx.c
+++ b/CMSISv2p00_LPC17xx/Drivers/src/lpc17xx_uartx.c
@@ -1,0 +1,485 @@
+/**
+ * @file        lpc17xx_uartx.c
+ * @brief       Contains all macro definitions and function prototypes
+ *              support for UART firmware library on LPC17xx
+ * @version     1.0
+ * @date        02. November. 2025
+ * @author      David Trujillo Medina
+ *
+ * Software that is described herein is for illustrative purposes only
+ * which provides customers with programming information regarding the
+ * products. This software is supplied "AS IS" without any warranties.
+ * NXP Semiconductors assumes no responsibility or liability for the
+ * use of the software, conveys no license or title under any patent,
+ * copyright, or mask work right to the product. NXP Semiconductors
+ * reserves the right to make changes in the software without
+ * notification. NXP Semiconductors also make no representation or
+ * warranty that such application will be suitable for the specified
+ * use without further testing or modification.
+ */
+
+/* ---------------------------- Peripheral group ---------------------------- */
+/** @addtogroup UARTX
+ * @{
+ */
+
+/* -------------------------------- Includes -------------------------------- */
+#include "lpc17xx_uartx.h"
+#include "lpc17xx_clkpwr.h"
+
+/* If this source file built with example, the LPC17xx FW library configuration
+ * file in each example directory ("lpc17xx_libcfg.h") must be included,
+ * otherwise the default FW library configuration file must be included instead
+ */
+#ifdef __BUILD_WITH_EXAMPLE__
+#include "lpc17xx_libcfg.h"
+#else
+#include "lpc17xx_libcfg_default.h"
+#endif /* __BUILD_WITH_EXAMPLE__ */
+
+#ifdef _UART
+/* ---------------------- Private Function Prototypes ----------------------- */
+/* ------------------- End of Private Function Prototypes ------------------- */
+
+/* --------------------------- Private Functions ---------------------------- */
+/**
+ * @brief        Determines best dividers to get a target clock rate
+ * @param[in]    UARTx    Pointer to selected UART peripheral, should be:
+ *                        - LPC_UART0: UART0 peripheral
+ *                        - LPC_UART2: UART2 peripheral
+ *                        - LPC_UART3: UART3 peripheral
+ * @param[in]    baudRate Desired UART baud rate.
+ * @return         Error status, could be:
+ *                 - SUCCESS
+ *                 - ERROR
+ */
+static Status uartSetDivisors(LPC_UARTX_TypeDef* UARTx, uint32_t baudRate) {
+    Status errorStatus = ERROR;
+
+    uint32_t uClk         = 0;
+    uint32_t calcBaudrate = 0;
+    uint32_t temp         = 0;
+
+    uint32_t diviser           = 0;
+    uint32_t mulFracDivOptimal = 1;
+    uint32_t dividerAddOptimal = 0;
+    uint32_t diviserOptimal    = 0;
+
+    uint32_t relativeError        = 0;
+    uint32_t relativeOptimalError = 100000;
+
+    /* get UART block clock */
+    switch ((uintptr_t)UARTx) {
+        case (uintptr_t)LPC_UART0: uClk = CLKPWR_GetPCLK(CLKPWR_PCLKSEL_UART0); break;
+        case (uintptr_t)LPC_UART2: uClk = CLKPWR_GetPCLK(CLKPWR_PCLKSEL_UART2); break;
+        case (uintptr_t)LPC_UART3: uClk = CLKPWR_GetPCLK(CLKPWR_PCLKSEL_UART3); break;
+        default: break;
+    }
+
+    uClk /= 16;
+
+    /* In the Uart IP block, baud rate is calculated using FDR and DLL-DLM registers
+    * The formula is :
+    * BaudRate= uClk * (mulFracDiv/(mulFracDiv+dividerAddFracDiv) / (16 * (DLL)
+    * It involves floating point calculations. That's the reason the formulae are adjusted with
+    * Multiply and divide method.*/
+    /* The value of mulFracDiv and dividerAddFracDiv should comply to the following expressions:
+    * 0 < mulFracDiv <= 15, 0 <= dividerAddFracDiv <= 15 */
+    for (uint32_t mulFracDiv = 1; mulFracDiv <= 15; mulFracDiv++) {
+        for (uint32_t dividerAddFracDiv = 0; dividerAddFracDiv <= 15; dividerAddFracDiv++) {
+            temp = (mulFracDiv * uClk) / ((mulFracDiv + dividerAddFracDiv));
+
+            diviser = temp / baudRate;
+            if ((temp % baudRate) > (baudRate / 2))
+                diviser++;
+
+            if (diviser > 2 && diviser < 65536) {
+                calcBaudrate = temp / diviser;
+
+                if (calcBaudrate <= baudRate)
+                    relativeError = baudRate - calcBaudrate;
+                else
+                    relativeError = calcBaudrate - baudRate;
+
+                if ((relativeError < relativeOptimalError)) {
+                    mulFracDivOptimal    = mulFracDiv;
+                    dividerAddOptimal    = dividerAddFracDiv;
+                    diviserOptimal       = diviser;
+                    relativeOptimalError = relativeError;
+                    if (relativeError == 0)
+                        break;
+                }
+            } /* End of if */
+        } /* end of inner for loop */
+        if (relativeError == 0)
+            break;
+    } /* end of outer for loop  */
+
+    if (relativeOptimalError < ((baudRate * UARTX_ACCEPTED_BAUDRATE_ERROR) / 100)) {
+        UARTx->LCR |= UARTX_LCR_DLAB_EN;
+        UARTx->DLM = UARTX_LOAD_DLM(diviserOptimal);
+        UARTx->DLL = UARTX_LOAD_DLL(diviserOptimal);
+        /* Then reset DLAB bit */
+        UARTx->LCR &= (~UARTX_LCR_DLAB_EN) & UARTX_LCR_BITMASK;
+        UARTx->FDR = (UARTX_FDR_MULVAL(mulFracDivOptimal) | UARTX_FDR_DIVADDVAL(dividerAddOptimal)) & UARTX_FDR_BITMASK;
+        errorStatus = SUCCESS;
+    }
+
+    return errorStatus;
+}
+/* ------------------------ End of Private Functions ------------------------ */
+
+/* ---------------------------- Public Functions ---------------------------- */
+/** @addtogroup UARTX_Public_Functions
+ * @{
+ */
+
+void UARTX_Init(LPC_UARTX_TypeDef* UARTx, const UARTX_CFG_Type* uartCfg) {
+    CHECK_PARAM(PARAM_UARTX(UARTx));
+    CHECK_PARAM(PARAM_UARTX_PARITY(uartCfg->parity));
+    CHECK_PARAM(PARAM_UARTX_CHAR_LENGTH(uartCfg->charLength));
+    CHECK_PARAM(PARAM_UARTX_STOPBITS(uartCfg->stopBits));
+
+    switch ((uintptr_t)UARTx) {
+        case (uintptr_t)LPC_UART0: CLKPWR_ConfigPPWR(CLKPWR_PCONP_PCUART0, ENABLE); break;
+        case (uintptr_t)LPC_UART2: CLKPWR_ConfigPPWR(CLKPWR_PCONP_PCUART2, ENABLE); break;
+        case (uintptr_t)LPC_UART3: CLKPWR_ConfigPPWR(CLKPWR_PCONP_PCUART3, ENABLE); break;
+        default: break;
+    }
+
+    UARTx->FCR = (UARTX_FCR_FIFO_EN | UARTX_FCR_RX_RS | UARTX_FCR_TX_RS);
+    UARTx->FCR = 0;
+
+    while (UARTx->LSR & UARTX_LSR_RDR) {
+        (void)UARTx->RBR;
+    }
+
+    UARTx->TER = UARTX_TER_TXEN;
+    while (!(UARTx->LSR & UARTX_LSR_THRE))
+        ;
+    UARTx->TER = 0;
+
+    UARTx->IER = 0;
+    UARTx->LCR = 0;
+    UARTx->ACR = 0;
+    (void)UARTx->LSR;
+    UARTx->ICR = 0;
+
+    uartSetDivisors(UARTx, (uartCfg->baudRate));
+
+    uint32_t lineCtrl = UARTx->LCR & (UARTX_LCR_DLAB_EN | UARTX_LCR_BREAK_EN);
+
+    switch (uartCfg->charLength) {
+        case UARTX_DATABIT_5: lineCtrl |= UARTX_DATABIT_5; break;
+        case UARTX_DATABIT_6: lineCtrl |= UARTX_DATABIT_6; break;
+        case UARTX_DATABIT_7: lineCtrl |= UARTX_DATABIT_7; break;
+        case UARTX_DATABIT_8: lineCtrl |= UARTX_DATABIT_8; break;
+        default: break;
+    }
+
+    if (uartCfg->parity != UARTX_PARITY_NONE) {
+        lineCtrl |= UARTX_LCR_PARITY_EN;
+        switch (uartCfg->parity) {
+            case UARTX_PARITY_ODD: lineCtrl |= UARTX_LCR_PARITY_ODD; break;
+            case UARTX_PARITY_EVEN: lineCtrl |= UARTX_LCR_PARITY_EVEN; break;
+            case UARTX_PARITY_1: lineCtrl |= UARTX_LCR_PARITY_F_1; break;
+            case UARTX_PARITY_0: lineCtrl |= UARTX_LCR_PARITY_F_0; break;
+            default: break;
+        }
+    }
+
+    switch (uartCfg->stopBits) {
+        case UARTX_STOPBITS_1: lineCtrl |= UARTX_LCR_STOPBIT_1; break;
+        case UARTX_STOPBITS_2: lineCtrl |= UARTX_LCR_STOPBIT_2; break;
+        default: break;
+    }
+
+    UARTx->LCR = lineCtrl & UARTX_LCR_BITMASK;
+}
+
+void UARTX_DeInit(LPC_UARTX_TypeDef* UARTx) {
+    CHECK_PARAM(PARAM_UARTX(UARTx));
+
+    UARTX_TxCmd(UARTx, DISABLE);
+
+    switch ((uintptr_t)UARTx) {
+        case (uintptr_t)LPC_UART0: CLKPWR_ConfigPPWR(CLKPWR_PCONP_PCUART0, DISABLE); break;
+        case (uintptr_t)LPC_UART2: CLKPWR_ConfigPPWR(CLKPWR_PCONP_PCUART2, DISABLE); break;
+        case (uintptr_t)LPC_UART3: CLKPWR_ConfigPPWR(CLKPWR_PCONP_PCUART3, DISABLE); break;
+        default: break;
+    }
+}
+
+void UARTX_FIFOConfig(LPC_UARTX_TypeDef* UARTx, const UARTX_FIFO_CFG_Type* fifoCfg) {
+    CHECK_PARAM(PARAM_UARTX(UARTx));
+    CHECK_PARAM(PARAM_UARTX_FIFO_LEVEL(fifoCfg->FIFOLevel));
+    CHECK_PARAM(PARAM_FUNCTIONALSTATE(fifoCfg->FIFODMAMode));
+    CHECK_PARAM(PARAM_FUNCTIONALSTATE(fifoCfg->FIFOResetRxBuf));
+    CHECK_PARAM(PARAM_FUNCTIONALSTATE(fifoCfg->FIFOResetTxBuf));
+
+    uint8_t tmp = UARTX_FCR_FIFO_EN;
+
+    switch (fifoCfg->FIFOLevel) {
+        case UARTX_FIFO_TRG_1: tmp |= UARTX_FIFO_TRG_1 << 6; break;
+        case UARTX_FIFO_TRG_4: tmp |= UARTX_FIFO_TRG_4 << 6; break;
+        case UARTX_FIFO_TRG_8: tmp |= UARTX_FIFO_TRG_8 << 6; break;
+        case UARTX_FIFO_TRG_14: tmp |= UARTX_FIFO_TRG_1 << 6; break;
+        default: break;
+    }
+
+    if (fifoCfg->FIFOResetTxBuf) {
+        tmp |= UARTX_FCR_TX_RS;
+    }
+    if (fifoCfg->FIFOResetRxBuf) {
+        tmp |= UARTX_FCR_RX_RS;
+    }
+    if (fifoCfg->FIFODMAMode) {
+        tmp |= UARTX_FCR_DMAMODE_SEL;
+    }
+
+    UARTx->FCR = tmp & UARTX_FCR_BITMASK;
+}
+
+void UARTX_SendByte(LPC_UARTX_TypeDef* UARTx, uint8_t byte) {
+    CHECK_PARAM(PARAM_UARTX(UARTx));
+
+    UARTx->THR = byte & UARTX_THR_MASKBIT;
+}
+
+uint8_t UARTX_ReceiveByte(LPC_UARTX_TypeDef* UARTx) {
+    CHECK_PARAM(PARAM_UARTX(UARTx));
+
+    return UARTx->RBR & UARTX_RBR_MASKBIT;
+}
+
+uint32_t UARTX_Send(LPC_UARTX_TypeDef* UARTx, const uint8_t* txBuff, uint32_t buffLen, Bool blocking) {
+    CHECK_PARAM(PARAM_UARTX(UARTx));
+
+    uint32_t fifoCnt;
+    const uint8_t* pChar = txBuff;
+    uint32_t bytesToSend = buffLen;
+    uint32_t bytesSent   = 0;
+
+    if (blocking == TRUE) {
+        while (bytesToSend) {
+            uint32_t timeOut = UARTX_BLOCKING_TIMEOUT;
+
+            while (!(UARTx->LSR & UARTX_LSR_THRE)) {
+                if (timeOut == 0) {
+                    break;
+                }
+                timeOut--;
+            }
+
+            if (timeOut == 0) {
+                break;
+            }
+
+            fifoCnt = UARTX_TX_FIFO_SIZE;
+            while (fifoCnt && bytesToSend) {
+                UARTX_SendByte(UARTx, *pChar++);
+                fifoCnt--;
+                bytesToSend--;
+                bytesSent++;
+            }
+        }
+    } else {
+        while (bytesToSend) {
+            if (!(UARTx->LSR & UARTX_LSR_THRE)) {
+                break;
+            }
+
+            fifoCnt = UARTX_TX_FIFO_SIZE;
+            while (fifoCnt && bytesToSend) {
+                UARTX_SendByte(UARTx, *pChar++);
+                bytesToSend--;
+                fifoCnt--;
+                bytesSent++;
+            }
+        }
+    }
+    return bytesSent;
+}
+
+uint32_t UARTX_Receive(LPC_UARTX_TypeDef* UARTx, uint8_t* rxBuff, uint32_t buffLen, Bool blocking) {
+    CHECK_PARAM(PARAM_UARTX(UARTx));
+    uint8_t* pChar = rxBuff;
+
+    uint32_t bytesToRecv = buffLen;
+    uint32_t bytesRecv   = 0;
+
+    if (blocking == TRUE) {
+        while (bytesToRecv) {
+            uint32_t timeOut = UARTX_BLOCKING_TIMEOUT;
+            while (!(UARTx->LSR & UARTX_LSR_RDR)) {
+                if (timeOut == 0)
+                    break;
+                timeOut--;
+            }
+
+            if (timeOut == 0) {
+                break;
+            }
+
+            *pChar++ = UARTX_ReceiveByte(UARTx);
+            bytesToRecv--;
+            bytesRecv++;
+        }
+    } else {
+        while (bytesToRecv) {
+            if (!(UARTx->LSR & UARTX_LSR_RDR)) {
+                break;
+            }
+
+            *pChar++ = UARTX_ReceiveByte(UARTx);
+            bytesRecv++;
+            bytesToRecv--;
+        }
+    }
+    return bytesRecv;
+}
+
+uint32_t UARTX_GetIntId(LPC_UARTX_TypeDef* UARTx) {
+    CHECK_PARAM(PARAM_UARTX(UARTx));
+
+    return UARTx->IIR & 0x03CF;
+}
+
+uint8_t UARTX_GetLineStatus(LPC_UARTX_TypeDef* UARTx) {
+    CHECK_PARAM(PARAM_UARTX(UARTx));
+
+    return UARTx->LSR & UARTX_LSR_BITMASK;
+}
+
+void UARTX_IntConfig(LPC_UARTX_TypeDef* UARTx, UARTX_INT option, FunctionalState newState) {
+    CHECK_PARAM(PARAM_UARTX(UARTx));
+    CHECK_PARAM(PARAM_FUNCTIONALSTATE(newState));
+    CHECK_PARAM(PARAM_UARTX_INT_CFG(option));
+
+    uint32_t intEnable = 0;
+
+    switch (option) {
+        case UARTX_INT_RBR: intEnable = UARTX_IER_RBRINT_EN; break;
+        case UARTX_INT_THRE: intEnable = UARTX_IER_THREINT_EN; break;
+        case UARTX_INT_RXLS: intEnable = UARTX_IER_RLSINT_EN; break;
+        case UARTX_INT_ABEO: intEnable = UARTX_IER_ABEOINT_EN; break;
+        case UARTX_INT_ABTO: intEnable = UARTX_IER_ABTOINT_EN; break;
+        default: break;
+    }
+
+    if (newState == ENABLE) {
+        UARTx->IER |= intEnable;
+    } else {
+        UARTx->IER &= ~intEnable & UARTX_IER_BITMASK;
+    }
+}
+
+void UARTX_TxCmd(LPC_UARTX_TypeDef* UARTx, FunctionalState newState) {
+    CHECK_PARAM(PARAM_UARTX(UARTx));
+    CHECK_PARAM(PARAM_FUNCTIONALSTATE(newState));
+
+    if (newState == ENABLE) {
+        UARTx->TER |= UARTX_TER_TXEN;
+    } else {
+        UARTx->TER &= ~UARTX_TER_TXEN & UARTX_TER_BITMASK;
+    }
+}
+
+FlagStatus UARTX_CheckBusy(LPC_UARTX_TypeDef* UARTx) {
+    CHECK_PARAM(PARAM_UARTX(UARTx));
+
+    if (UARTx->LSR & UARTX_LSR_TEMT) {
+        return RESET;
+    }
+    return SET;
+}
+
+void UARTX_ForceBreak(LPC_UARTX_TypeDef* UARTx) {
+    CHECK_PARAM(PARAM_UARTX(UARTx));
+
+    UARTx->LCR |= UARTX_LCR_BREAK_EN;
+}
+
+void UARTX_ABClearIntPending(LPC_UARTX_TypeDef* UARTx, UARTX_INT abIntType) {
+    CHECK_PARAM(PARAM_UARTX(UARTx));
+    CHECK_PARAM(PARAM_UARTX_AB_INT(abIntType));
+
+    if (abIntType == UARTX_INT_ABEO) {
+        UARTx->ACR |= UARTX_IIR_ABEO_INT;
+    } else {
+        UARTx->ACR |= UARTX_IIR_ABTO_INT;
+    }
+}
+
+void UARTX_ABCmd(LPC_UARTX_TypeDef* UARTx, UARTX_AB_CFG_Type* abCfg, FunctionalState newState) {
+    CHECK_PARAM(PARAM_UARTX(UARTx));
+    CHECK_PARAM(PARAM_FUNCTIONALSTATE(newState));
+
+    uint32_t baudCtrl = 0;
+    if (newState == ENABLE) {
+        if (abCfg->abMode == UARTX_AUTOBAUD_MODE1) {
+            baudCtrl |= UARTX_ACR_MODE;
+        }
+
+        if (abCfg->autoRestart == ENABLE) {
+            baudCtrl |= UARTX_ACR_AUTO_RESTART;
+        }
+    }
+
+    if (newState == ENABLE) {
+        UARTx->LCR |= UARTX_LCR_DLAB_EN;
+        UARTx->DLL = 0;
+        UARTx->DLM = 0;
+
+        UARTx->LCR &= ~UARTX_LCR_DLAB_EN;
+
+        UARTx->FDR = 0x10;
+        UARTx->ACR = UARTX_ACR_START | baudCtrl;
+    } else {
+        UARTx->ACR = 0;
+    }
+}
+
+void UARTX_IrDAInvtInputCmd(LPC_UARTX_TypeDef* UARTx, FunctionalState newState) {
+    CHECK_PARAM(PARAM_UARTX(UARTx));
+    CHECK_PARAM(PARAM_FUNCTIONALSTATE(newState));
+
+    if (newState == ENABLE) {
+        UARTx->ICR |= UARTX_ICR_IRDAINV;
+    } else {
+        UARTx->ICR &= (~UARTX_ICR_IRDAINV) & UARTX_ICR_BITMASK;
+    }
+}
+
+void UARTX_IrDACmd(LPC_UARTX_TypeDef* UARTx, FunctionalState newState) {
+    CHECK_PARAM(PARAM_UARTX(UARTx));
+    CHECK_PARAM(PARAM_FUNCTIONALSTATE(newState));
+
+    if (newState == ENABLE) {
+        UARTx->ICR |= UARTX_ICR_IRDAEN;
+    } else {
+        UARTx->ICR &= (~UARTX_ICR_IRDAEN) & UARTX_ICR_BITMASK;
+    }
+}
+
+void UARTX_IrDAPulseDivConfig(LPC_UARTX_TypeDef* UARTx, UARTX_IrDA_PULSE_Type pulseDiv) {
+    CHECK_PARAM(PARAM_UARTX(UARTx));
+    CHECK_PARAM(PARAM_UARTX_IrDA_PULSE_DIV(pulseDiv));
+
+    uint32_t tmp1 = UARTX_ICR_PULSEDIV(pulseDiv);
+    uint32_t tmp = UARTx->ICR & (~UARTX_ICR_PULSEDIV(7));
+    tmp |= tmp1 | UARTX_ICR_FIXPULSE_EN;
+    UARTx->ICR = tmp & UARTX_ICR_BITMASK;
+}
+
+/**
+ * @}
+ */
+
+#endif  // _UART
+
+/**
+ * @}
+ */
+
+/* ------------------------------ End Of File ------------------------------- */

--- a/CMSISv2p00_LPC17xx/inc/LPC17xx.h
+++ b/CMSISv2p00_LPC17xx/inc/LPC17xx.h
@@ -350,39 +350,7 @@ typedef struct
   __IO uint8_t  TER;
        uint8_t  RESERVED6[39];
   __IO uint32_t FIFOLVL;
-} LPC_UART_TypeDef;
-
-typedef struct
-{
-  union {
-  __I  uint8_t  RBR;
-  __O  uint8_t  THR;
-  __IO uint8_t  DLL;
-       uint32_t RESERVED0;
-  };
-  union {
-  __IO uint8_t  DLM;
-  __IO uint32_t IER;
-  };
-  union {
-  __I  uint32_t IIR;
-  __O  uint8_t  FCR;
-  };
-  __IO uint8_t  LCR;
-       uint8_t  RESERVED1[7];
-  __I  uint8_t  LSR;
-       uint8_t  RESERVED2[7];
-  __IO uint8_t  SCR;
-       uint8_t  RESERVED3[3];
-  __IO uint32_t ACR;
-  __IO uint8_t  ICR;
-       uint8_t  RESERVED4[3];
-  __IO uint8_t  FDR;
-       uint8_t  RESERVED5[7];
-  __IO uint8_t  TER;
-       uint8_t  RESERVED6[39];
-  __IO uint32_t FIFOLVL;
-} LPC_UART0_TypeDef;
+} LPC_UARTX_TypeDef;
 
 typedef struct
 {
@@ -996,10 +964,10 @@ typedef struct
 #define LPC_TIM2              ((LPC_TIM_TypeDef       *) LPC_TIM2_BASE     )
 #define LPC_TIM3              ((LPC_TIM_TypeDef       *) LPC_TIM3_BASE     )
 #define LPC_RIT               ((LPC_RIT_TypeDef       *) LPC_RIT_BASE      )
-#define LPC_UART0             ((LPC_UART0_TypeDef     *) LPC_UART0_BASE    )
+#define LPC_UART0             ((LPC_UARTX_TypeDef     *) LPC_UART0_BASE    )
 #define LPC_UART1             ((LPC_UART1_TypeDef     *) LPC_UART1_BASE    )
-#define LPC_UART2             ((LPC_UART_TypeDef      *) LPC_UART2_BASE    )
-#define LPC_UART3             ((LPC_UART_TypeDef      *) LPC_UART3_BASE    )
+#define LPC_UART2             ((LPC_UARTX_TypeDef     *) LPC_UART2_BASE    )
+#define LPC_UART3             ((LPC_UARTX_TypeDef     *) LPC_UART3_BASE    )
 #define LPC_PWM1              ((LPC_PWM_TypeDef       *) LPC_PWM1_BASE     )
 #define LPC_I2C0              ((LPC_I2C_TypeDef       *) LPC_I2C0_BASE     )
 #define LPC_I2C1              ((LPC_I2C_TypeDef       *) LPC_I2C1_BASE     )


### PR DESCRIPTION
- Unified `LPC_UART_TypeDef` and `LPC_UART0_TypeDef` into `LPC_UARTX_TypeDef` in `CMSISv2p00_LPC17xx/inc/LPC17xx.h`.
- Split general UART driver into `uartx` (shared implementation for UART0, UART2, UART3) and a separate `uart1` driver (to be implemented).
- Added/updated `UARTX_Init(LPC_UARTX_TypeDef* UARTx, const UARTX_CFG_Type* uartCfg)` and moved common functionality to `CMSISv2p00_LPC17xx/Drivers/src/lpc17xx_uartx.c`.
- Preserved UART1-specific features (modem/RS485) for a dedicated implementation.
- Updated headers/usages to use `LPC_UARTX_TypeDef`.

BREAKING CHANGE: public typedefs renamed — update code referencing `LPC_UART_TypeDef` or `LPC_UART0_TypeDef` to `LPC_UARTX_TypeDef`.