### PR TITLE
Fix case sensitive header imports

### DIFF
--- a/CMSISv2p00_LPC17xx/.gitignore
+++ b/CMSISv2p00_LPC17xx/.gitignore
@@ -1,3 +1,5 @@
 Release
+Debug
+.settings/language.settings.xml
 ../CMakeLists.txt
 ../.clang-format

--- a/CMSISv2p00_LPC17xx/Drivers/inc/lpc17xx_clkpwr.h
+++ b/CMSISv2p00_LPC17xx/Drivers/inc/lpc17xx_clkpwr.h
@@ -28,7 +28,7 @@
 #define LPC17XX_CLKPWR_H_
 
 /* Includes ------------------------------------------------------------------- */
-#include "lpc17xx.h"
+#include "LPC17xx.h"
 #include "lpc_types.h"
 
 #ifdef __cplusplus

--- a/CMSISv2p00_LPC17xx/Drivers/inc/lpc17xx_pinsel.h
+++ b/CMSISv2p00_LPC17xx/Drivers/inc/lpc17xx_pinsel.h
@@ -28,7 +28,7 @@
 #define LPC17XX_PINSEL_H_
 
 /* -------------------------------- Includes -------------------------------- */
-#include "lpc17xx.h"
+#include "LPC17xx.h"
 #include "lpc17xx_common.h"
 #include "lpc_types.h"
 


### PR DESCRIPTION
## Description

Closes #44 

* Changed the two occurrences of lowercase includes of the `LPC17xx.h` header with the correct filename, fixing builds in case-sensitive file systems as described in #44
* Added `Debug/` and `.settings/language.settings.xml` to `.gitignore` to prevent dirtying the tree when working on MCUXpresso.

## Demo

Test suite runs, proving the library can now be built. Test failures are unrelated to the changes.

```
Test PINSEL_ConfigPinFunctionLowTest passed
Test PINSEL_ConfigPinFunctionHighTest passed
Test PINSEL_ConfigPinModeLowTest passed
Test PINSEL_ConfigPinModeHighTest passed
Test PINSEL_ConfigPinODTest passed
Test PINSEL_ConfigMultiplePinsTest passed
Passed 6/6 PINSEL tests

Test GPIO_SetDirTest passed
Test GPIO_SetValueTest passed
EXPECT_EQUAL failed in: GPIO_ClearValueTest. lpc17xx_gpio_tests.c:129
Got: 2139066367 Expected: 2147454975
EXPECT_EQUAL failed in: GPIO_ClearValueTest. lpc17xx_gpio_tests.c:133
Got: 2139062512 Expected: 2147451120
EXPECT_EQUAL failed in: GPIO_ClearValueTest. lpc17xx_gpio_tests.c:137
Got: 2139062272 Expected: 2147450880
Test GPIO_ClearValueTest failed
Test GPIO_SetPinStateTest passed
EXPECT_EQUAL failed in: GPIO_WriteValueTest. lpc17xx_gpio_tests.c:177
Got: 8359680 Expected: 16748288
Test GPIO_WriteValueTest failed
Test GPIO_ReadValueTest passed
EXPECT_EQUAL failed in: GPIO_TogglePinsTest. lpc17xx_gpio_tests.c:210
Got: 2139062287 Expected: 2147450895
Test GPIO_TogglePinsTest failed
Test GPIO_SetMaskTest passed
Test GPIO_IntConfigPortTest passed
Test GPIO_GetPortIntStatusTest passed
Test GPIO_GetPinIntStatusTest passed
Test GPIO_ClearIntTest passed
Test FIO_HalfWordSetDirTest passed
EXPECT_EQUAL failed in: FIO_HalfWordSetValueTest. lpc17xx_gpio_tests.c:388
Got: 259002127 Expected: 267390735
EXPECT_EQUAL failed in: FIO_HalfWordSetValueTest. lpc17xx_gpio_tests.c:392
Got: 2138050319 Expected: 2146438927
Test FIO_HalfWordSetValueTest failed
EXPECT_EQUAL failed in: FIO_HalfWordClearValueTest. lpc17xx_gpio_tests.c:403
Got: 2139066367 Expected: 2147454975
EXPECT_EQUAL failed in: FIO_HalfWordClearValueTest. lpc17xx_gpio_tests.c:407
Got: 2139062512 Expected: 2147451120
EXPECT_EQUAL failed in: FIO_HalfWordClearValueTest. lpc17xx_gpio_tests.c:411
Got: 2139062272 Expected: 2147450880
Test FIO_HalfWordClearValueTest failed
Test FIO_HalfWordWriteValueTest passed
Test FIO_HalfWordReadValueTest passed
EXPECT_EQUAL failed in: FIO_HalfWordTogglePinsTest. lpc17xx_gpio_tests.c:468
Got: 1886392304 Expected: 1894780912
Test FIO_HalfWordTogglePinsTest failed
Test FIO_HalfWordSetMaskTest passed
Test FIO_ByteSetDirTest passed
Test FIO_ByteSetValueTest passed
EXPECT_EQUAL failed in: FIO_ByteClearValueTest. lpc17xx_gpio_tests.c:535
Got: 2139066367 Expected: 2147454975
EXPECT_EQUAL failed in: FIO_ByteClearValueTest. lpc17xx_gpio_tests.c:539
Got: 2139066352 Expected: 2147454960
EXPECT_EQUAL failed in: FIO_ByteClearValueTest. lpc17xx_gpio_tests.c:543
Got: 2139066352 Expected: 2147454960
EXPECT_EQUAL failed in: FIO_ByteClearValueTest. lpc17xx_gpio_tests.c:547
Got: 260018160 Expected: 268406768
Test FIO_ByteClearValueTest failed
Test FIO_ByteWriteValueTest passed
Test FIO_ByteReadValueTest passed
Test FIO_ByteTogglePinsTest passed
Test FIO_ByteSetMaskTest passed
Passed 19/26 GPIO tests

Test SYSTICK_InternalInitTest passed
Test SYSTICK_ExternalInitTest passed
Test SYSTICK_CmdTest passed
Test SYSTICK_IntCmdTest passed
Test SYSTICK_GetCurrentValueTest passed
Test SYSTICK_ClearCounterFlagTest passed
Test SYSTICK_GetReloadValueTest passed
Test SYSTICK_SetReloadValueTest passed
Test SYSTICK_IsActiveTest passed
Test SYSTICK_HasFiredTest passed
Passed 10/10 SYSTICK tests

Test EXTI_InitTest passed
Test EXTI_ConfigTest passed
Test EXTI_ConfigEnableTest passed
Test EXTI_ClearFlagTest passed
Test EXTI_GetFlagTest passed
Test EXTI_EnableIRQTest passed
Passed 6/6 EXTI tests

Test TIM_InitTimerTest passed
Test TIM_InitCounterTest passed
Test TIM_DeInitTest passed
Test TIM_ClearIntPendingTest passed
Test TIM_GetIntStatusTest passed
Test TIM_ConfigMatchTest passed
Test TIM_UpdateMatchValueTest passed
Test TIM_SetMatchExtTest passed
Test TIM_ConfigCaptureTest passed
Test TIM_CmdTest passed
Test TIM_GetCaptureValueTest passed
Test TIM_ResetCounterTest passed
Passed 12/12 TIMER tests

Test PWM_InitTimerTest passed
Test PWM_InitCounterTest passed
Test PWM_DeInitTest passed
Test PWM_ChannelConfigTest passed
Test PWM_ChannelCmdTest passed
Test PWM_CmdTest passed
Test PWM_CounterCmdTest passed
Test PWM_ResetCounterTest passed
Test PWM_ConfigMatchTest passed
Test PWM_MatchUpdateSingleTest passed
Test PWM_MatchUpdateDoubleTest passed
Test PWM_ClearIntPendingTest passed
Test PWM_GetIntStatusTest passed
Test PWM_ConfigCaptureTest passed
Test PWM_GetCaptureValueTest passed
Passed 15/15 PWM tests

Test ADC_InitTest passed
Test ADC_DeInitTest passed
Test ADC_BurstCmdTest passed
Test ADC_PowerdownCmdTest passed
Test ADC_StartCmdTest passed
Test ADC_ChannelCmdTest passed
Test ADC_EdgeStartConfigTest passed
Test ADC_IntConfigTest passed
Test ADC_GlobalGetStatusTest passed
Test ADC_ChannelGetStatusTest passed
Test ADC_GlobalGetDataTest passed
Test ADC_ChannelGetDataTest passed
Passed 12/12 ADC tests

Test DAC_InitTest passed
Test DAC_UpdateValueTest passed
Test DAC_SetBiasTest passed
Test DAC_ConfigDAConverterControlTest passed
Test DAC_SetDMATimeOutTest passed
Passed 5/5 DAC tests

Test GPDMA_InitTest passed
Test GPDMA_DeInitTest passed
Test GPDMA_SetupChannelTest passed
Test GPDMA_ChannelStartStopTest passed
Test GPDMA_ChannelPauseResumeTest passed
Test GPDMA_ChannelGracefulStopTest passed
Test GPDMA_IntGetStatusTest passed
Test GPDMA_ClearIntPendingTest passed
Passed 8/8 GPDMA tests

Test UART_InitTest passed
Test UART_DeInitTest passed
Test UART_InitAllDataBitsTest passed
Test UART_InitAllParitiesTest passed
Test UART_InitAllStopBitsTest passed
Test UART_FIFOConfigTest passed
Test UART_TxEnableDisableTest passed
Test UART_IntConfigTest passed
Test UART_IntConfig1OnlyTest passed
Test UART_GetLineStatusTest passed
Test UART_CheckBusyTest passed
[ℹ️ INFO] UART_SendReceiveLoopbackTest: P0.2 (TX0) to P0.3 (RX0) must be connected.
```